### PR TITLE
Rename CRM contacts to leads

### DIFF
--- a/crm/agendamentos/api_dados_relacionados.php
+++ b/crm/agendamentos/api_dados_relacionados.php
@@ -54,7 +54,7 @@ try {
         case 'get_cliente_by_id':
             $cliente_id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
             if (!$cliente_id) {
-                echo json_encode(['error' => 'ID do contato inválido.']);
+                echo json_encode(['error' => 'ID do lead inválido.']);
                 exit();
             }
             // Correção: Usar 'nome_cliente' em vez de 'nome_empresa'

--- a/crm/agendamentos/calendario.php
+++ b/crm/agendamentos/calendario.php
@@ -84,7 +84,7 @@ try {
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
-                        <label for="cliente_id" class="block text-sm font-medium text-gray-700">Contato (Opcional)</label>
+                        <label for="cliente_id" class="block text-sm font-medium text-gray-700">Lead (Opcional)</label>
                         <select class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" id="cliente_id" name="cliente_id">
                             <option value="">Nenhum</option>
                             <?php foreach ($clientes as $cliente): ?>
@@ -342,7 +342,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     if (data && data.cliente_id) {
                         clienteSelect.value = data.cliente_id;
                     } else {
-                        alert('Esta prospecção não está associada a nenhum contato.');
+                        alert('Esta prospecção não está associada a nenhum lead.');
                     }
                 })
                 .catch(error => {
@@ -407,7 +407,7 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
         if (!clienteIdParaNovaProspeccao) {
-            alert('Não foi possível associar a nova prospecção a um contato. Tente novamente.');
+            alert('Não foi possível associar a nova prospecção a um lead. Tente novamente.');
             return;
         }
         

--- a/crm/agendamentos/novo_agendamento.php
+++ b/crm/agendamentos/novo_agendamento.php
@@ -26,7 +26,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
 <div class="bg-white shadow sm:rounded-lg p-6">
     <h1 class="text-2xl font-bold text-gray-800 mb-2">Novo Agendamento</h1>
     <!-- Correção 3: Exibir 'nome_cliente' -->
-    <p class="text-sm text-gray-600 mb-6">Para a oportunidade: <span class="font-semibold"><?php echo htmlspecialchars($dados_prospeccao['nome_prospecto']); ?></span> com o contato <span class="font-semibold"><?php echo htmlspecialchars($dados_prospeccao['nome_cliente']); ?></span>.</p>
+    <p class="text-sm text-gray-600 mb-6">Para a oportunidade: <span class="font-semibold"><?php echo htmlspecialchars($dados_prospeccao['nome_prospecto']); ?></span> com o lead <span class="font-semibold"><?php echo htmlspecialchars($dados_prospeccao['nome_cliente']); ?></span>.</p>
 
 <form action="<?php echo APP_URL; ?>/crm/agendamentos/salvar_agendamento.php" method="POST" class="space-y-6">
         <input type="hidden" name="prospeccao_id" value="<?php echo $prospeccao_id; ?>">

--- a/crm/clientes/editar_cliente.php
+++ b/crm/clientes/editar_cliente.php
@@ -18,23 +18,23 @@ try {
     $cliente = $stmt->fetch(PDO::FETCH_ASSOC);
 
     if (!$cliente) {
-        $_SESSION['error_message'] = "Contato não encontrado.";
+        $_SESSION['error_message'] = "Lead não encontrado.";
         header('Location: ' . APP_URL . '/crm/clientes/lista.php');
         exit;
     }
 
 } catch (PDOException $e) {
-    die("Erro ao buscar dados do contato: " . $e->getMessage());
+    die("Erro ao buscar dados do lead: " . $e->getMessage());
 }
 
-$pageTitle = "Editar Contato";
+$pageTitle = "Editar Lead";
 require_once __DIR__ . '/../../app/views/layouts/header.php';
 ?>
 
 <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
     <div class="md:flex md:items-center md:justify-between border-b border-gray-200 pb-4">
         <h1 class="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:truncate">
-            Editar Contato: <span class="text-blue-600"><?php echo htmlspecialchars($cliente['nome_cliente']); ?></span>
+            Editar Lead: <span class="text-blue-600"><?php echo htmlspecialchars($cliente['nome_cliente']); ?></span>
         </h1>
     </div>
 
@@ -50,11 +50,11 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
-                <label for="nome_cliente" class="block text-sm font-medium text-gray-700">Nome do Contato / Empresa</label>
+                <label for="nome_cliente" class="block text-sm font-medium text-gray-700">Nome do Lead / Empresa</label>
                 <input type="text" name="nome_cliente" id="nome_cliente" required class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3" value="<?php echo htmlspecialchars($cliente['nome_cliente']); ?>">
             </div>
             <div>
-                <label for="nome_responsavel" class="block text-sm font-medium text-gray-700">Nome do Contato Principal</label>
+                <label for="nome_responsavel" class="block text-sm font-medium text-gray-700">Nome do Lead Principal</label>
                 <input type="text" name="nome_responsavel" id="nome_responsavel" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3" value="<?php echo htmlspecialchars($cliente['nome_responsavel']); ?>">
             </div>
             <div>
@@ -87,7 +87,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                     <option value="Qualificado" <?php echo ($cliente['categoria'] == 'Qualificado') ? 'selected' : ''; ?>>Qualificado</option>
                     <option value="Com Orçamento" <?php echo ($cliente['categoria'] == 'Com Orçamento') ? 'selected' : ''; ?>>Com Orçamento</option>
                     <option value="Em Negociação" <?php echo ($cliente['categoria'] == 'Em Negociação') ? 'selected' : ''; ?>>Em Negociação</option>
-                    <option value="Cliente Ativo" <?php echo ($cliente['categoria'] == 'Cliente Ativo') ? 'selected' : ''; ?>>Contato Ativo</option>
+                    <option value="Cliente Ativo" <?php echo ($cliente['categoria'] == 'Cliente Ativo') ? 'selected' : ''; ?>>Lead Ativo</option>
                     <option value="Sem Interesse" <?php echo ($cliente['categoria'] == 'Sem Interesse') ? 'selected' : ''; ?>>Sem Interesse</option>
                 </select>
             </div>
@@ -96,7 +96,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
         <div class="pt-5 flex justify-between items-center border-t border-gray-200 mt-6">
             <div>
                 <button type="button" onclick="confirmarExclusao()" class="bg-red-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-red-700 transition duration-300">
-                    Excluir Contato
+                    Excluir Lead
                 </button>
             </div>
 
@@ -114,7 +114,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
 
 <script>
     function confirmarExclusao() {
-        if (confirm('ATENÇÃO:\n\nTem certeza que deseja excluir este contato?\n\nTodas as prospecções ligadas a ele ficarão sem contatos associado.')) {
+        if (confirm('ATENÇÃO:\n\nTem certeza que deseja excluir este lead?\n\nTodas as prospecções ligadas a ele ficarão sem leads associados.')) {
             document.getElementById('formExcluirCliente').submit();
         }
     }

--- a/crm/clientes/excluir_cliente.php
+++ b/crm/clientes/excluir_cliente.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_POST['id'])) {
 
 $cliente_id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
 if (!$cliente_id) {
-    die("ID de contato inválido.");
+    die("ID de lead inválido.");
 }
 
 // Inicia uma transação para garantir a integridade dos dados
@@ -36,13 +36,13 @@ try {
     $pdo->commit();
 
     // 5. Redireciona de volta para a lista com mensagem de sucesso
-    $_SESSION['success_message'] = "Contato excluído com sucesso.";
+    $_SESSION['success_message'] = "Lead excluído com sucesso.";
     header('Location: ' . APP_URL . '/crm/clientes/lista.php');
     exit;
 
 } catch (PDOException $e) {
     // Se qualquer operação falhar, desfaz todas as alterações
     $pdo->rollBack();
-    die("Erro ao excluir o contato. Pode haver registros associados que impedem a exclusão. Erro: " . $e->getMessage());
+    die("Erro ao excluir o lead. Pode haver registros associados que impedem a exclusão. Erro: " . $e->getMessage());
 }
 ?>

--- a/crm/clientes/integracao_bitrix.php
+++ b/crm/clientes/integracao_bitrix.php
@@ -63,7 +63,7 @@ if ($action === 'fetch_bitrix') {
         $_SESSION['bitrix_import_data'] = $all_contacts;
         $contacts_from_bitrix = $all_contacts;
     } else {
-        $feedback_message = "Nenhum contato encontrado no Bitrix24 ou erro na API.";
+        $feedback_message = "Nenhum lead encontrado no Bitrix24 ou erro na API.";
         $feedback_type = 'info';
     }
 }
@@ -73,7 +73,7 @@ if ($action === 'import_selected') {
     $selected_contacts_ids = $_POST['contact_ids'] ?? [];
 
     if (empty($selected_contacts_ids)) {
-        $feedback_message = "Nenhum contato foi selecionado para importação.";
+        $feedback_message = "Nenhum lead foi selecionado para importação.";
         $feedback_type = 'error';
         $contacts_from_bitrix = $_SESSION['bitrix_import_data'] ?? [];
     } else {
@@ -116,7 +116,7 @@ if ($action === 'import_selected') {
         }
         
         $pdo->commit();
-        $feedback_message = "Importação concluída! <strong>{$count_adicionados}</strong> novos contatos importados. <strong>{$count_ignorados}</strong> contatos ignorados (já existiam).";
+        $feedback_message = "Importação concluída! <strong>{$count_adicionados}</strong> novos leads importados. <strong>{$count_ignorados}</strong> leads ignorados (já existiam).";
         $feedback_type = 'success';
         
         unset($_SESSION['bitrix_import_data']);
@@ -131,7 +131,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
 <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
     <div class="md:flex md:items-center md:justify-between border-b border-gray-200 pb-4 mb-6">
         <h1 class="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:truncate">
-            Importar Contatos do Bitrix24
+            Importar Leads do Bitrix24
         </h1>
     </div>
 
@@ -142,11 +142,11 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
 
     <?php if (empty($contacts_from_bitrix)): ?>
         <div class="text-center">
-            <p class="text-gray-600 mb-4">Clique no botão para buscar os contatos do Bitrix24 e visualizá-los antes de importar.</p>
+            <p class="text-gray-600 mb-4">Clique no botão para buscar os leads do Bitrix24 e visualizá-los antes de importar.</p>
             <form action="<?php echo APP_URL; ?>/crm/clientes/integracao_bitrix.php" method="POST">
                 <input type="hidden" name="action" value="fetch_bitrix">
                 <button type="submit" class="bg-blue-600 text-white font-bold py-3 px-6 rounded-lg hover:bg-blue-700 text-lg shadow-lg">
-                    Buscar Contatos do Bitrix24
+                    Buscar Leads do Bitrix24
                 </button>
             </form>
         </div>

--- a/crm/clientes/lista.php
+++ b/crm/clientes/lista.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/../../app/models/Cliente.php';
 $clienteModel = new Cliente($pdo);
 $clientes = $clienteModel->getCrmProspects();
 
-$pageTitle = "CRM - Lista de Contatos";
+$pageTitle = "CRM - Lista de Leads";
 require_once __DIR__ . '/../../app/views/layouts/header.php';
 ?>
 
@@ -21,7 +21,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
         <h1 class="text-3xl font-bold text-gray-800"><?php echo $pageTitle; ?></h1>
         <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php" class="bg-blue-600 text-white py-2 px-4 rounded-md shadow-md hover:bg-blue-700 transition duration-300 flex items-center">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" /></svg>
-            Novo Contato
+            Novo Lead
         </a>
     </div>
 
@@ -42,7 +42,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                 <thead>
                     <tr>
                         <th class="px-6 py-3 border-b-2 border-gray-200 bg-gray-50 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Nome / Empresa</th>
-                        <th class="px-6 py-3 border-b-2 border-gray-200 bg-gray-50 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Contato</th>
+                        <th class="px-6 py-3 border-b-2 border-gray-200 bg-gray-50 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Lead</th>
                         <th class="px-6 py-3 border-b-2 border-gray-200 bg-gray-50 text-center text-xs font-semibold text-gray-600 uppercase tracking-wider">Status</th>
                         <th class="px-6 py-3 border-b-2 border-gray-200 bg-gray-50 text-center text-xs font-semibold text-gray-600 uppercase tracking-wider">Ações</th>
                     </tr>
@@ -82,7 +82,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                                         <?php endif; ?>
                                         <a href="<?php echo APP_URL; ?>/crm/clientes/editar_cliente.php?id=<?php echo $cliente['id']; ?>" class="text-blue-600 hover:text-blue-800 font-semibold">Editar</a>
 
-                                        <form action="<?php echo APP_URL; ?>/crm/clientes/excluir_cliente.php" method="POST" onsubmit="return confirm('Tem certeza que deseja excluir este contato?');">
+                                        <form action="<?php echo APP_URL; ?>/crm/clientes/excluir_cliente.php" method="POST" onsubmit="return confirm('Tem certeza que deseja excluir este lead?');">
                                             <input type="hidden" name="id" value="<?php echo $cliente['id']; ?>">
                                             <button type="submit" class="text-red-600 hover:text-red-800 font-semibold">Excluir</button>
                                         </form>

--- a/crm/clientes/novo.php
+++ b/crm/clientes/novo.php
@@ -16,7 +16,7 @@ if (strpos($redirectUrl, APP_URL) !== 0) {
 <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
     <div class="md:flex md:items-center md:justify-between border-b border-gray-200 pb-4">
         <h1 class="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:truncate">
-            Cadastrar Novo Contato
+            Cadastrar Novo Lead
         </h1>
     </div>
     
@@ -26,12 +26,12 @@ if (strpos($redirectUrl, APP_URL) !== 0) {
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 
                 <div class="md:col-span-2">
-                    <label for="nome_cliente" class="block text-sm font-medium text-gray-700">Nome do Contato / Empresa</label>
+                    <label for="nome_cliente" class="block text-sm font-medium text-gray-700">Nome do Lead / Empresa</label>
                     <input type="text" name="nome_cliente" id="nome_cliente" required class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
                 </div>
 
                 <div>
-                    <label for="nome_responsavel" class="block text-sm font-medium text-gray-700">Nome do Contato Principal <span class="text-gray-500 font-normal">(Opcional)</span></label>
+                    <label for="nome_responsavel" class="block text-sm font-medium text-gray-700">Nome do Lead Principal <span class="text-gray-500 font-normal">(Opcional)</span></label>
                     <input type="text" name="nome_responsavel" id="nome_responsavel" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
                 </div>
                 
@@ -63,13 +63,13 @@ if (strpos($redirectUrl, APP_URL) !== 0) {
                 </div>
 
                 <div class="md:col-span-2">
-                    <label for="categoria" class="block text-sm font-medium text-gray-700">Categoria do Contato</label>
+                    <label for="categoria" class="block text-sm font-medium text-gray-700">Categoria do Lead</label>
                     <select name="categoria" id="categoria" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
                         <option value="Entrada">Entrada</option>
                         <option value="Qualificado">Qualificado</option>
                         <option value="Com Orçamento">Com Orçamento</option>
                         <option value="Em Negociação">Em Negociação</option>
-                        <option value="Cliente Ativo">Contato Ativo</option>
+                        <option value="Cliente Ativo">Lead Ativo</option>
                         <option value="Sem Interesse">Sem Interesse</option>
                     </select>
                 </div>
@@ -77,7 +77,7 @@ if (strpos($redirectUrl, APP_URL) !== 0) {
 
             <div class="pt-5 flex justify-end border-t mt-6">
                 <a href="<?php echo APP_URL; ?>/crm/clientes/lista.php" class="bg-gray-200 text-gray-700 font-bold py-2 px-4 rounded-lg hover:bg-gray-300 mr-3">Cancelar</a>
-                <button type="submit" class="bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700">Salvar Contato</button>
+                <button type="submit" class="bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700">Salvar Lead</button>
             </div>
         </form>
     </div>

--- a/crm/clientes/salvar.php
+++ b/crm/clientes/salvar.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     // Validação
     if (empty($nome_cliente) || empty($canal_origem)) {
-        $_SESSION['error_message'] = "Nome do Cliente e Canal de Origem são obrigatórios.";
+        $_SESSION['error_message'] = "Nome do Lead e Canal de Origem são obrigatórios.";
         header('Location: ' . $redirectUrl);
         exit();
     }
@@ -42,13 +42,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $clienteExistente = $stmtCheckProspect->fetch(PDO::FETCH_ASSOC);
 
             if (!$clienteExistente) {
-                $_SESSION['error_message'] = "Cliente não encontrado.";
+                $_SESSION['error_message'] = "Lead não encontrado.";
                 header('Location: ' . APP_URL . '/crm/clientes/lista.php');
                 exit();
             }
 
             if ((int) ($clienteExistente['is_prospect'] ?? 0) !== 1) {
-                $_SESSION['error_message'] = "Este contato já foi convertido em cliente e deve ser gerenciado pelo sistema principal.";
+                $_SESSION['error_message'] = "Este lead já foi convertido em cliente e deve ser gerenciado pelo sistema principal.";
                 header('Location: ' . APP_URL . '/crm/clientes/lista.php');
                 exit();
             }
@@ -67,7 +67,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt = $pdo->prepare($sql);
             $stmt->execute($params);
 
-            $_SESSION['success_message'] = "Cliente atualizado com sucesso!";
+            $_SESSION['success_message'] = "Lead atualizado com sucesso!";
             $redirect_location = APP_URL . '/crm/clientes/lista.php';
 
         } else {
@@ -86,7 +86,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt->execute($params);
 
             $novo_cliente_id = $pdo->lastInsertId();
-            $_SESSION['success_message'] = "Contato criado com sucesso! Agora cadastre a prospecção.";
+            $_SESSION['success_message'] = "Lead criado com sucesso! Agora cadastre a prospecção.";
 
             $redirectBase = $_POST['redirect_url'] ?? '';
             if (empty($redirectBase) || strpos($redirectBase, APP_URL) !== 0) {
@@ -101,7 +101,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         exit;
 
     } catch (PDOException $e) {
-        die("Erro ao salvar cliente: " . $e->getMessage());
+        die("Erro ao salvar lead: " . $e->getMessage());
     }
 
 } else {

--- a/crm/dashboard.php
+++ b/crm/dashboard.php
@@ -151,7 +151,7 @@ require_once __DIR__ . '/../app/views/layouts/header.php';
         <div class="mt-4" style="height: 300px;"><canvas id="graficoResponsavel"></canvas></div>
     </div>
     <div class="bg-white overflow-hidden shadow rounded-lg p-6 lg:col-span-2">
-        <h3 class="text-lg font-medium leading-6 text-gray-900">Contatos por Canal de Origem</h3>
+        <h3 class="text-lg font-medium leading-6 text-gray-900">Leads por Canal de Origem</h3>
         <div class="mt-4" style="height: 300px;"><canvas id="graficoCanais"></canvas></div>
     </div>
 </div>
@@ -170,7 +170,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
     
     // Gráfico de Canais
     const ctxCanais = document.getElementById('graficoCanais').getContext('2d');
-    new Chart(ctxCanais, { type: 'bar', data: { labels: <?php echo json_encode($labels_canal); ?>, datasets: [{ label: 'Contatos por Canal', data: <?php echo json_encode($valores_canal); ?>, backgroundColor: 'rgba(59, 130, 246, 0.7)', }] }, options: { scales: { y: { beginAtZero: true } }, responsive: true, maintainAspectRatio: false } });
+    new Chart(ctxCanais, { type: 'bar', data: { labels: <?php echo json_encode($labels_canal); ?>, datasets: [{ label: 'Leads por Canal', data: <?php echo json_encode($valores_canal); ?>, backgroundColor: 'rgba(59, 130, 246, 0.7)', }] }, options: { scales: { y: { beginAtZero: true } }, responsive: true, maintainAspectRatio: false } });
 });
 </script>
 

--- a/crm/prospeccoes/atualizar.php
+++ b/crm/prospeccoes/atualizar.php
@@ -86,7 +86,7 @@ try {
                 $pdo->beginTransaction();
 
                 if (!$clienteModel->promoteProspectToClient($clienteId)) {
-                    throw new RuntimeException('Falha ao promover o contato a cliente.');
+                    throw new RuntimeException('Falha ao promover o lead a cliente.');
                 }
 
                 $novoProcessoId = $processoModel->createFromProspeccao($dadosParaProcesso);

--- a/crm/prospeccoes/detalhes.php
+++ b/crm/prospeccoes/detalhes.php
@@ -62,7 +62,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                 <div class="flex justify-between items-start mb-6">
                     <div>
                         <h2 class="text-2xl font-bold text-gray-900"><?php echo htmlspecialchars($prospect['nome_prospecto'] ?? ''); ?></h2>
-                        <p class="text-sm text-gray-500">Contato: <span class="font-medium text-indigo-600"><?php echo htmlspecialchars($prospect['nome_cliente'] ?? 'Cliente não vinculado'); ?></span></p>
+                        <p class="text-sm text-gray-500">Lead: <span class="font-medium text-indigo-600"><?php echo htmlspecialchars($prospect['nome_cliente'] ?? 'Lead não vinculado'); ?></span></p>
                         <p class="text-sm text-gray-500 mt-1">ID: <?php echo htmlspecialchars($prospect['id_texto'] ?? ''); ?></p>
                     </div>
                     
@@ -108,7 +108,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                         <div>
                             <label for="status" class="block text-sm font-medium text-gray-700">Status</label>
                             <select name="status" id="status" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
-                                <option value="Cliente ativo" <?php echo ($prospect['status'] == 'Cliente ativo') ? 'selected' : ''; ?>>Contato ativo</option>
+                                <option value="Cliente ativo" <?php echo ($prospect['status'] == 'Cliente ativo') ? 'selected' : ''; ?>>Lead ativo</option>
                                 <option value="Primeiro contato" <?php echo ($prospect['status'] == 'Primeiro contato') ? 'selected' : ''; ?>>Primeiro contato</option>
                                 <option value="Segundo contato" <?php echo ($prospect['status'] == 'Segundo contato') ? 'selected' : ''; ?>>Segundo contato</option>
                                 <option value="Terceiro contato" <?php echo ($prospect['status'] == 'Terceiro contato') ? 'selected' : ''; ?>>Terceiro contato</option>

--- a/crm/prospeccoes/kanban.php
+++ b/crm/prospeccoes/kanban.php
@@ -149,7 +149,7 @@ try {
                 <?php foreach ($prospeccoes_por_status[$status] as $prospeccao): ?>
                     <div class="bg-white p-3 rounded-lg shadow-sm kanban-card" data-id="<?php echo $prospeccao['id']; ?>">
                         <p class="font-semibold text-sm text-gray-800"><?php echo htmlspecialchars($prospeccao['nome_prospecto']); ?></p>
-                        <p class="text-xs text-gray-600 mt-1"><?php echo htmlspecialchars($prospeccao['nome_cliente'] ?? 'Contato não associado'); ?></p>
+                        <p class="text-xs text-gray-600 mt-1"><?php echo htmlspecialchars($prospeccao['nome_cliente'] ?? 'Lead não associado'); ?></p>
                         <div class="flex justify-between items-center mt-3">
                             
                             <p class="text-xs text-blue-600 font-bold">R$ <?php echo number_format($prospeccao['valor_proposto'] ?? 0, 2, ',', '.'); ?></p>

--- a/crm/prospeccoes/lista.php
+++ b/crm/prospeccoes/lista.php
@@ -113,7 +113,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
             <!-- Campo de busca -->
             <div>
                 <label for="search" class="block text-sm font-medium text-gray-600 mb-2">Buscar</label>
-                <input type="text" name="search" id="search" class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" value="<?php echo htmlspecialchars($search_term); ?>" placeholder="Nome do prospecto ou contato...">
+                <input type="text" name="search" id="search" class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" value="<?php echo htmlspecialchars($search_term); ?>" placeholder="Nome do prospecto ou lead...">
             </div>
 
             <!-- Campo de status -->
@@ -172,7 +172,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
             <thead class="bg-gray-50">
                 <tr>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Prospecto</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Contato</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Lead</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
                     <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Valor</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Responsável</th>
@@ -189,7 +189,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                     <?php foreach ($prospeccoes as $prospeccao): ?>
                         <tr>
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"><?php echo htmlspecialchars($prospeccao['nome_prospecto']); ?></td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600"><?php echo htmlspecialchars($prospeccao['nome_cliente'] ?? 'N/A'); ?></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600"><?php echo htmlspecialchars($prospeccao['nome_cliente'] ?? 'Lead não vinculado'); ?></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                                 <span class="
                                     <?php 

--- a/crm/prospeccoes/nova.php
+++ b/crm/prospeccoes/nova.php
@@ -8,7 +8,7 @@ try {
     $stmt_clientes = $pdo->query("SELECT id, nome_cliente FROM clientes WHERE is_prospect = 1 ORDER BY nome_cliente ASC");
     $clientes = $stmt_clientes->fetchAll(PDO::FETCH_ASSOC);
 } catch (PDOException $e) {
-    die("Erro ao buscar contatos: " . $e->getMessage());
+    die("Erro ao buscar leads: " . $e->getMessage());
 }
 
 $cliente_pre_selecionado_id = filter_input(INPUT_GET, 'cliente_id', FILTER_VALIDATE_INT);
@@ -41,14 +41,14 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
 
     <?php if (empty($clientes)): ?>
         <div class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-6" role="alert">
-            <p class="font-bold">Nenhum contato encontrado!</p>
-            <p>Você precisa cadastrar um contato antes. <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php" class="font-bold underline hover:text-yellow-800">Clique aqui para cadastrar.</a></p>
+            <p class="font-bold">Nenhum lead encontrado!</p>
+            <p>Você precisa cadastrar um lead antes. <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php" class="font-bold underline hover:text-yellow-800">Clique aqui para cadastrar.</a></p>
         </div>
     <?php else: ?>
         <form action="<?php echo APP_URL; ?>/crm/prospeccoes/salvar.php" method="POST" id="form-nova-prospeccao" class="space-y-6">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div class="md:col-span-2">
-                    <label for="cliente_id" class="block text-sm font-medium text-gray-700">Contato Associado</label>
+                    <label for="cliente_id" class="block text-sm font-medium text-gray-700">Lead Associado</label>
                     <div class="flex items-center space-x-2 mt-1">
                         <select name="cliente_id" id="cliente_id" class="block w-full">
                             <option></option> <?php foreach ($clientes as $cliente): ?>
@@ -57,9 +57,9 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                                 </option>
                             <?php endforeach; ?>
                         </select>
-                        <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php?redirect_url=<?php echo urlencode(APP_URL . '/crm/prospeccoes/nova.php'); ?>" 
+                        <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php?redirect_url=<?php echo urlencode(APP_URL . '/crm/prospeccoes/nova.php'); ?>"
                         class="flex-shrink-0 bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-md text-sm">
-                            Novo Contato
+                            Novo Lead
                         </a>
                     </div>
                 </div>                
@@ -74,7 +74,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                 <div class="md:col-span-2">
                     <label for="status" class="block text-sm font-medium text-gray-700">Status Inicial</label>
                     <select name="status" id="status" required class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
-                        <option value="Cliente ativo">Contato ativo</option>
+                        <option value="Cliente ativo">Lead ativo</option>
                         <option value="Primeiro contato">Primeiro contato</option>
                         <option value="Segundo contato">Segundo contato</option>
                         <option value="Terceiro contato">Terceiro contato</option>
@@ -108,7 +108,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
         // --- INÍCIO DA CORREÇÃO PRINCIPAL ---
         
         $('#cliente_id').select2({
-            placeholder: "Selecione um contato...",
+            placeholder: "Selecione um lead...",
             allowClear: true
         });
 
@@ -122,7 +122,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                 // Se o valor for nulo ou vazio, impede o envio e mostra um alerta
                 if (!clienteId || clienteId === '') {
                     event.preventDefault(); // Impede o envio do formulário
-                    alert('Erro: Por favor, selecione um contato associado.');
+                    alert('Erro: Por favor, selecione um lead associado.');
                 }
                 // Se houver um valor, o formulário será enviado normalmente.
             });

--- a/crm/prospeccoes/solicitar_exclusao.php
+++ b/crm/prospeccoes/solicitar_exclusao.php
@@ -44,7 +44,7 @@ try {
         <ul>
             <li><strong>ID:</strong> " . htmlspecialchars($prospect['id_texto']) . "</li>
             <li><strong>Oportunidade:</strong> " . htmlspecialchars($prospect['nome_prospecto']) . "</li>
-            <li><strong>Contato:</strong> " . htmlspecialchars($prospect['nome_cliente']) . "</li>
+            <li><strong>Lead:</strong> " . htmlspecialchars($prospect['nome_cliente']) . "</li>
         </ul>
         <p><strong>Motivo da solicitação:</strong></p>
         <p style='padding: 10px; border: 1px solid #eee; background-color: #f9f9f9;'>" . nl2br(htmlspecialchars($motivo)) . "</p>


### PR DESCRIPTION
## Summary
- Rename CRM customer management pages and messages to use "Lead" terminology instead of "Contato"
- Align prospecting and scheduling flows, including alerts and placeholders, with the lead nomenclature
- Update dashboard labels and Bitrix import feedback to reflect the lead wording

## Testing
- php -l crm/agendamentos/api_dados_relacionados.php
- php -l crm/agendamentos/calendario.php
- php -l crm/agendamentos/novo_agendamento.php
- php -l crm/clientes/editar_cliente.php
- php -l crm/clientes/excluir_cliente.php
- php -l crm/clientes/integracao_bitrix.php
- php -l crm/clientes/lista.php
- php -l crm/clientes/novo.php
- php -l crm/clientes/salvar.php
- php -l crm/dashboard.php
- php -l crm/prospeccoes/atualizar.php
- php -l crm/prospeccoes/detalhes.php
- php -l crm/prospeccoes/kanban.php
- php -l crm/prospeccoes/lista.php
- php -l crm/prospeccoes/nova.php
- php -l crm/prospeccoes/solicitar_exclusao.php

------
https://chatgpt.com/codex/tasks/task_e_68dfc2cd995c8330aa274b413557e661