### PR TITLE
Permitir conversão de orçamento pelo vendedor

### DIFF
--- a/app/models/Processo.php
+++ b/app/models/Processo.php
@@ -529,7 +529,7 @@ public function getFilteredProcesses(array $filters = [], int $limit = 50, int $
     $params = [];
     // Se nenhum filtro de status for aplicado, exclui os orçamentos por padrão.
     if (empty($filters['status'])) {
-        $where_clauses[] = "p.status_processo NOT IN ('Orçamento', 'Recusado', 'Pendente')";
+        $where_clauses[] = "p.status_processo NOT IN ('Orçamento', 'Orçamento Pendente', 'Recusado', 'Pendente', 'Serviço Pendente')";
 
     }
 
@@ -539,7 +539,7 @@ public function getFilteredProcesses(array $filters = [], int $limit = 50, int $
     if (!empty($filters['filtro_card'])) {
         switch ($filters['filtro_card']) {
             case 'ativos':
-                $where_clauses[] = "p.status_processo IN ('Aprovado', 'Em Andamento')";
+                $where_clauses[] = "p.status_processo IN ('Aprovado', 'Em Andamento', 'Serviço em Andamento')";
                 break;
             case 'finalizados_mes':
                 $where_clauses[] = "p.status_processo = 'Finalizado' AND MONTH(p.data_finalizacao_real) = MONTH(CURDATE()) AND YEAR(p.data_finalizacao_real) = YEAR(CURDATE())";
@@ -602,8 +602,8 @@ public function getFilteredProcesses(array $filters = [], int $limit = 50, int $
     }
 
     $where_part = !empty($where_clauses) ? ' WHERE ' . implode(' AND ', $where_clauses) : '';
-    $order_part = " ORDER BY 
-        (CASE WHEN p.status_processo = 'Orçamento' THEN 1 ELSE 0 END),
+    $order_part = " ORDER BY
+        (CASE WHEN p.status_processo IN ('Orçamento', 'Orçamento Pendente') THEN 1 ELSE 0 END),
         p.data_criacao DESC";
     $limit_offset_part = " LIMIT :limit OFFSET :offset";
     $sql = $select_part . $from_part . $where_part . $order_part . $limit_offset_part;
@@ -638,7 +638,7 @@ public function getTotalFilteredProcessesCount(array $filters = []): int
     
     // Garante que a contagem também exclua os orçamentos por padrão.
     if (empty($filters['status'])) {
-        $where_clauses[] = "p.status_processo NOT IN ('Orçamento', 'Recusado', 'Pendente')";
+        $where_clauses[] = "p.status_processo NOT IN ('Orçamento', 'Orçamento Pendente', 'Recusado', 'Pendente', 'Serviço Pendente')";
 
     }
 
@@ -732,7 +732,7 @@ public function getTotalFilteredProcessesCount(array $filters = []): int
                 LEFT JOIN users AS u ON v.user_id = u.id
                 LEFT JOIN formas_pagamento AS fp ON p.forma_pagamento_id = fp.id";
 
-        $where = ["p.status_processo NOT IN ('Orçamento', 'Cancelado')"];
+        $where = ["p.status_processo NOT IN ('Orçamento', 'Orçamento Pendente', 'Cancelado')"];
         $params = [];
 
         if (!empty($filters['data_inicio'])) {
@@ -781,7 +781,7 @@ public function getTotalFilteredProcessesCount(array $filters = []): int
     public function getOverallFinancialSummary($start_date, $end_date, array $filters = []): array
     {
         // --- Constrói a base da query e das cláusulas WHERE ---
-        $base_where_sql = " FROM processos p WHERE p.data_criacao BETWEEN :start_date AND :end_date AND p.status_processo NOT IN ('Orçamento', 'Cancelado')";
+        $base_where_sql = " FROM processos p WHERE p.data_criacao BETWEEN :start_date AND :end_date AND p.status_processo NOT IN ('Orçamento', 'Orçamento Pendente', 'Cancelado')";
         $params = [
             ':start_date' => $start_date . ' 00:00:00',
             ':end_date' => $end_date . ' 23:59:59'
@@ -1346,7 +1346,7 @@ public function getTotalFilteredProcessesCount(array $filters = []): int
         $sql = "SELECT SUM(p.valor_total) as total_vendas_mes
                 FROM processos p
                 WHERE p.vendedor_id = :vendedor_id
-                  AND p.status_processo NOT IN ('Orçamento', 'Cancelado')
+                  AND p.status_processo NOT IN ('Orçamento', 'Orçamento Pendente', 'Cancelado')
                   AND MONTH(p.data_criacao) = MONTH(CURDATE())
                   AND YEAR(p.data_criacao) = YEAR(CURDATE())";
     

--- a/app/views/dashboard/main.php
+++ b/app/views/dashboard/main.php
@@ -126,7 +126,7 @@ $initialProcessLimit = 50; // Altere este valor conforme necessário
                     <label for="status" class="text-sm font-semibold text-gray-700 mb-1">Status</label>
                     <select id="status" name="status" class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-lg appearance-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white transition duration-200">
                         <option value="">Todos os Status</option>
-                        <?php $status_list = ['Orçamento', 'Aprovado', 'Em Andamento', 'Finalizado', 'Arquivado', 'Cancelado']; foreach($status_list as $s): ?>
+                        <?php $status_list = ['Orçamento', 'Orçamento Pendente', 'Serviço Pendente', 'Serviço em Andamento', 'Em Andamento', 'Aprovado', 'Finalizado', 'Arquivado', 'Cancelado']; foreach(array_unique($status_list) as $s): ?>
                             <option value="<?php echo $s; ?>" <?php echo (($filters['status'] ?? '') == $s) ? 'selected' : ''; ?>><?php echo $s; ?></option>
                         <?php endforeach; ?>
                     </select>
@@ -194,16 +194,23 @@ $initialProcessLimit = 50; // Altere este valor conforme necessário
                             $rowClass = 'hover:bg-gray-50'; // Cor padrão
                             switch ($processo['status_processo']) {
                                 case 'Orçamento':
+                                case 'Orçamento Pendente':
                                     $rowClass = 'bg-blue-50 hover:bg-blue-100';
                                     break;
                                 case 'Aprovado':
                                     $rowClass = 'bg-green-50 hover:bg-green-100';
+                                    break;
+                                case 'Serviço Pendente':
+                                    $rowClass = 'bg-orange-50 hover:bg-orange-100';
                                     break;
                                 case 'Finalizado':
                                     $rowClass = 'bg-purple-50 hover:bg-purple-100';
                                     break;
                                 case 'Cancelado':
                                     $rowClass = 'bg-red-50 hover:bg-red-100';
+                                    break;
+                                case 'Serviço em Andamento':
+                                    $rowClass = 'bg-cyan-50 hover:bg-cyan-100';
                                     break;
                                 // 'Em Andamento' fica com a cor padrão
                             }

--- a/app/views/processos/detalhe.php
+++ b/app/views/processos/detalhe.php
@@ -31,16 +31,32 @@ function format_prazo_countdown($dateString) {
 $status = $processo['status_processo'] ?? 'N/A';
 $status_classes = 'bg-gray-100 text-gray-800';
 switch ($status) {
-    case 'Orçamento': $status_classes = 'bg-yellow-100 text-yellow-800'; break;
-    case 'Aprovado': $status_classes = 'bg-blue-100 text-blue-800'; break;
-    case 'Em Andamento': $status_classes = 'bg-cyan-100 text-cyan-800'; break;
-    case 'Serviço Pendente': $status_classes = 'bg-orange-100 text-orange-800'; break;
-    case 'Finalizado': $status_classes = 'bg-green-100 text-green-800'; break;
-    case 'Arquivado': $status_classes = 'bg-gray-200 text-gray-600'; break;
-    case 'Cancelado': $status_classes = 'bg-red-100 text-red-800'; break;
+    case 'Orçamento':
+    case 'Orçamento Pendente':
+        $status_classes = 'bg-yellow-100 text-yellow-800';
+        break;
+    case 'Aprovado':
+        $status_classes = 'bg-blue-100 text-blue-800';
+        break;
+    case 'Serviço Pendente':
+        $status_classes = 'bg-orange-100 text-orange-800';
+        break;
+    case 'Em Andamento':
+    case 'Serviço em Andamento':
+        $status_classes = 'bg-cyan-100 text-cyan-800';
+        break;
+    case 'Finalizado':
+        $status_classes = 'bg-green-100 text-green-800';
+        break;
+    case 'Arquivado':
+        $status_classes = 'bg-gray-200 text-gray-600';
+        break;
+    case 'Cancelado':
+        $status_classes = 'bg-red-100 text-red-800';
+        break;
 }
 $leadConversionContext = $leadConversionContext ?? ['shouldRender' => false];
-$isAprovadoOuSuperior = !in_array($status, ['Orçamento', 'Cancelado']);
+$isAprovadoOuSuperior = !in_array($status, ['Orçamento', 'Orçamento Pendente', 'Cancelado']);
 ?>
 
 
@@ -53,6 +69,15 @@ $isAprovadoOuSuperior = !in_array($status, ['Orçamento', 'Cancelado']);
         <span id="display-status-badge" class="px-3 py-1.5 inline-flex text-sm leading-5 font-semibold rounded-full <?php echo $status_classes; ?>">
             <?php echo htmlspecialchars($status); ?>
         </span>
+        <?php if (!empty($leadConversionContext['shouldRender'])): ?>
+            <button
+                type="button"
+                id="open-lead-conversion-modal"
+                class="bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded-lg shadow-sm"
+            >
+                Converter em Serviço
+            </button>
+        <?php endif; ?>
         <a
             href="processos.php?action=exibir_orcamento&id=<?php echo $processo['id']; ?>"
             target="_blank"
@@ -91,7 +116,11 @@ $isAprovadoOuSuperior = !in_array($status, ['Orçamento', 'Cancelado']);
             </div>
         </div>
         <?php if (!empty($leadConversionContext['shouldRender'])): ?>
-            <div id="lead-conversion-modal" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60">
+            <div
+                id="lead-conversion-modal"
+                class="fixed inset-0 z-50 hidden items-center justify-center bg-black bg-opacity-60"
+                aria-hidden="true"
+            >
                 <div class="relative bg-white rounded-2xl shadow-2xl w-full max-w-5xl" style="width:70%; max-height:80vh; overflow-y:auto;">
                     <div class="sticky top-0 flex items-center justify-end px-6 py-4 bg-white border-b border-gray-200">
                         <button type="button" id="close-lead-conversion-modal" class="text-sm text-gray-500 hover:text-gray-700">Fechar ✕</button>
@@ -344,7 +373,7 @@ $isAprovadoOuSuperior = !in_array($status, ['Orçamento', 'Cancelado']);
                     <div>
                         <label for="status_processo" class="block text-sm font-medium text-gray-700">Mudar Status para:</label>
                         <select id="status_processo" name="status_processo" class="mt-1 block w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                            <?php $allStatus = ['Orçamento', 'Serviço Pendente', 'Aprovado', 'Em Andamento', 'Finalizado', 'Arquivado', 'Cancelado']; ?>
+                            <?php $allStatus = ['Orçamento Pendente', 'Orçamento', 'Serviço Pendente', 'Serviço em Andamento', 'Aprovado', 'Em Andamento', 'Finalizado', 'Arquivado', 'Cancelado']; ?>
                             <?php foreach ($allStatus as $stat): ?>
                                 <option value="<?php echo $stat; ?>" <?php echo ($processo['status_processo'] == $stat) ? 'selected' : ''; ?>>
                                     <?php echo $stat; ?>
@@ -870,9 +899,43 @@ document.addEventListener('DOMContentLoaded', function() {
 
   const leadConversionModal = $id('lead-conversion-modal');
   const closeLeadConversionModalBtn = $id('close-lead-conversion-modal');
+  const openLeadConversionModalBtn = $id('open-lead-conversion-modal');
+
+  const toggleBodyScroll = (shouldLock) => {
+    if (!document.body) {
+      return;
+    }
+    document.body.classList[shouldLock ? 'add' : 'remove']('overflow-hidden');
+  };
+
+  const showLeadConversionModal = () => {
+    if (!leadConversionModal) {
+      return;
+    }
+    leadConversionModal.classList.remove('hidden');
+    leadConversionModal.setAttribute('aria-hidden', 'false');
+    toggleBodyScroll(true);
+  };
+
+  const hideLeadConversionModal = () => {
+    if (!leadConversionModal) {
+      return;
+    }
+    leadConversionModal.classList.add('hidden');
+    leadConversionModal.setAttribute('aria-hidden', 'true');
+    toggleBodyScroll(false);
+  };
+
+  if (openLeadConversionModalBtn) {
+    openLeadConversionModalBtn.addEventListener('click', showLeadConversionModal);
+  }
+
   if (leadConversionModal && closeLeadConversionModalBtn) {
-    closeLeadConversionModalBtn.addEventListener('click', () => {
-      leadConversionModal.remove();
+    closeLeadConversionModalBtn.addEventListener('click', hideLeadConversionModal);
+    leadConversionModal.addEventListener('click', (event) => {
+      if (event.target === leadConversionModal) {
+        hideLeadConversionModal();
+      }
     });
   }
 

--- a/app/views/vendedor_dashboard/main.php
+++ b/app/views/vendedor_dashboard/main.php
@@ -98,7 +98,7 @@ $dashboardVendedorUrl = $baseAppUrl . '/dashboard_vendedor.php';
                 <label for="status" class="text-sm font-semibold text-gray-700 mb-1 block">Status</label>
                 <select id="status" name="status" class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-lg">
                     <option value="">Todos os Status</option>
-                    <?php $status_list = ['Orçamento', 'Orçamento Pendente', 'Em andamento', 'Serviço Pendente', 'Finalizado']; foreach($status_list as $s): ?>
+                    <?php $status_list = ['Orçamento', 'Orçamento Pendente', 'Serviço Pendente', 'Serviço em Andamento', 'Em andamento', 'Finalizado']; foreach(array_unique($status_list) as $s): ?>
                         <option value="<?php echo $s; ?>" <?php echo (($filters['status'] ?? '') == $s) ? 'selected' : ''; ?>><?php echo $s; ?></option>
                     <?php endforeach; ?>
                 </select>


### PR DESCRIPTION
## Summary
- habilitar o vendedor responsável a acessar o fluxo de conversão do orçamento em serviço
- adicionar botão explícito no detalhe do processo para abrir o wizard e ajustar os estilos/comportamento do modal
- alinhar listas e filtros de status ao novo fluxo incluindo Orçamento Pendente, Serviço Pendente e Serviço em Andamento

## Testing
- php -l app/controllers/ProcessosController.php
- php -l app/views/processos/detalhe.php
- php -l app/models/Processo.php
- php -l app/views/vendedor_dashboard/main.php
- php -l app/views/dashboard/main.php

------
https://chatgpt.com/codex/tasks/task_e_68dfe158c2508330ba59e59aa5e3366c