### PR TITLE
Implement async lead conversion wizard step submissions

### DIFF
--- a/app/views/processos/request_service_form.php
+++ b/app/views/processos/request_service_form.php
@@ -38,6 +38,7 @@ $prazoAcordado = $clienteContext['prazo_acordado_dias'] ?? ($context['prazoAcord
         method="POST"
         enctype="multipart/form-data"
         data-wizard-form
+        data-step-endpoint="processos.php?action=lead_conversion_step"
     >
         <input type="hidden" name="id" value="<?php echo (int)$processo['id']; ?>">
         <input type="hidden" name="status_processo" value="<?php echo htmlspecialchars($context['statusDestino'] ?? 'Serviço Pendente'); ?>">

--- a/processos.php
+++ b/processos.php
@@ -27,6 +27,7 @@ switch ($action) {
 
     case 'edit':
     case 'change_status':
+    case 'lead_conversion_step':
         // Permite que o vendedor acesse estas rotas.
         require_permission(['admin', 'gerencia', 'supervisor', 'vendedor']);
         break;
@@ -92,6 +93,9 @@ switch ($action) {
         break;
     case 'change_status':
         $controller->changeStatus();
+        break;
+    case 'lead_conversion_step':
+        $controller->leadConversionStep();
         break;
     case 'delete':
         $controller->delete($id); // Ajuste aqui para passar o $id


### PR DESCRIPTION
## Summary
- add a controller endpoint to persist lead data per wizard step and synchronize clients with Omie
- expose the new step endpoint in the conversion form and enhance the wizard controller to submit steps asynchronously with inline feedback
- register routing and permission handling for the lead conversion step API

## Testing
- php -l app/controllers/ProcessosController.php
- php -l processos.php

------
https://chatgpt.com/codex/tasks/task_e_68e007aca2508330804b539b95334436