### PR TITLE
Adicionar campo de prazo acordado em clientes e serviços

### DIFF
--- a/app/controllers/ClientesController.php
+++ b/app/controllers/ClientesController.php
@@ -331,6 +331,15 @@ class ClientesController
             }
         }
 
+        if (isset($data['prazo_acordado_dias'])) {
+            $prazoAcordado = trim((string) $data['prazo_acordado_dias']);
+            if ($prazoAcordado !== '') {
+                if (!ctype_digit($prazoAcordado) || (int) $prazoAcordado <= 0) {
+                    $errors[] = 'Informe um prazo acordado válido (número inteiro maior que zero).';
+                }
+            }
+        }
+
         return $errors;
     }
 
@@ -425,6 +434,11 @@ class ClientesController
         $data['estado'] = strtoupper(trim((string) ($data['estado'] ?? '')));
         $data['cep'] = trim((string) ($data['cep'] ?? ''));
         $data['cpf_cnpj'] = trim((string) ($data['cpf_cnpj'] ?? ''));
+
+        if (array_key_exists('prazo_acordado_dias', $data)) {
+            $prazoAcordado = trim((string) $data['prazo_acordado_dias']);
+            $data['prazo_acordado_dias'] = $prazoAcordado === '' ? null : (int) $prazoAcordado;
+        }
 
         return $data;
     }

--- a/app/models/Cliente.php
+++ b/app/models/Cliente.php
@@ -85,20 +85,24 @@ class Cliente
                 }
             }
             
-            $sql = "UPDATE clientes SET 
-                        nome_cliente = ?, nome_responsavel = ?, cpf_cnpj = ?, 
-                        email = ?, telefone = ?, endereco = ?, numero = ?, bairro = ?, cidade = ?, estado = ?, cep = ?, 
-                        tipo_pessoa = ?, tipo_assessoria = ?, user_id = ? 
+            $prazoAcordadoDias = array_key_exists('prazo_acordado_dias', $data)
+                ? $data['prazo_acordado_dias']
+                : ($clienteAtual['prazo_acordado_dias'] ?? null);
+
+            $sql = "UPDATE clientes SET
+                        nome_cliente = ?, nome_responsavel = ?, cpf_cnpj = ?,
+                        email = ?, telefone = ?, endereco = ?, numero = ?, bairro = ?, cidade = ?, estado = ?, cep = ?,
+                        tipo_pessoa = ?, tipo_assessoria = ?, prazo_acordado_dias = ?, user_id = ?
                     WHERE id = ?";
-            
+
             $stmt = $this->pdo->prepare($sql);
             $stmt->execute([
                 $data['nome_cliente'], $data['nome_responsavel'] ?? null, $cpf_cnpj,
-                $data['email'] ?? null, $data['telefone'] ?? null, 
-                $data['endereco'] ?? null, $data['numero'] ?? null, $data['bairro'] ?? null, 
+                $data['email'] ?? null, $data['telefone'] ?? null,
+                $data['endereco'] ?? null, $data['numero'] ?? null, $data['bairro'] ?? null,
                 $data['cidade'] ?? null, $data['estado'] ?? null,
-                $data['cep'] ?? null, $data['tipo_pessoa'] ?? 'Jurídica', // Salva o tipo de pessoa
-                $data['tipo_assessoria'] ?? null, $userId, $id
+                $data['cep'] ?? null, $data['tipo_pessoa'] ?? 'Jurídica',
+                $data['tipo_assessoria'] ?? null, $prazoAcordadoDias, $userId, $id
             ]);
             
             $this->pdo->commit();
@@ -299,13 +303,13 @@ class Cliente
             }
 
             // --- CORREÇÃO AQUI ---
-            $sql = "INSERT INTO clientes 
-                        (nome_cliente, nome_responsavel, cpf_cnpj, email, telefone, endereco, numero, bairro, cidade, estado, cep, tipo_pessoa, tipo_assessoria, user_id, is_prospect) 
-                    VALUES 
-                        (:nome_cliente, :nome_responsavel, :cpf_cnpj, :email, :telefone, :endereco, :numero, :bairro, :cidade, :estado, :cep, :tipo_pessoa, :tipo_assessoria, :user_id, :is_prospect)";
-            
+            $sql = "INSERT INTO clientes
+                        (nome_cliente, nome_responsavel, cpf_cnpj, email, telefone, endereco, numero, bairro, cidade, estado, cep, tipo_pessoa, tipo_assessoria, prazo_acordado_dias, user_id, is_prospect)
+                    VALUES
+                        (:nome_cliente, :nome_responsavel, :cpf_cnpj, :email, :telefone, :endereco, :numero, :bairro, :cidade, :estado, :cep, :tipo_pessoa, :tipo_assessoria, :prazo_acordado_dias, :user_id, :is_prospect)";
+
             $stmt = $this->pdo->prepare($sql);
-            
+
             $stmt->execute([
                 ':nome_cliente' => $data['nome_cliente'],
                 ':nome_responsavel' => $data['nome_responsavel'] ?? null,
@@ -320,6 +324,7 @@ class Cliente
                 ':cep' => $data['cep'] ?? null,
                 ':tipo_pessoa' => $data['tipo_pessoa'] ?? 'Jurídica',
                 ':tipo_assessoria' => $data['tipo_assessoria'] ?? null,
+                ':prazo_acordado_dias' => $data['prazo_acordado_dias'] ?? null,
                 ':user_id' => $userId,
                 ':is_prospect' => 0 // Define como cliente normal, e não prospecção
             ]);

--- a/app/views/clientes/form.php
+++ b/app/views/clientes/form.php
@@ -16,6 +16,7 @@ $formValues = array_merge($cliente, $formData);
 
 // Preenche as variáveis para os campos do formulário
 $nome_cliente = $formValues['nome_cliente'] ?? '';
+$prazo_acordado_dias = $formValues['prazo_acordado_dias'] ?? '';
 $nome_responsavel = $formValues['nome_responsavel'] ?? '';
 $cpf_cnpj = $formValues['cpf_cnpj'] ?? '';
 $email = $formValues['email'] ?? '';
@@ -91,6 +92,24 @@ require_once __DIR__ . '/../layouts/header.php';
             <label for="nome_cliente" id="label_nome_cliente" class="block text-sm font-semibold text-gray-700">Nome do Cliente / Empresa *</label>
             <input type="text" id="nome_cliente" name="nome_cliente" autocomplete="nope" value="<?php echo htmlspecialchars($nome_cliente); ?>" class="mt-1 block w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500" required>
         </div>
+
+        <?php
+            $userPerfil = $_SESSION['user_perfil'] ?? '';
+            $perfisPrazoVisivel = ['admin', 'gerencia', 'supervisor', 'colaborador'];
+        ?>
+        <?php if (in_array($userPerfil, $perfisPrazoVisivel, true)): ?>
+            <div class="md:col-span-1">
+                <label for="prazo_acordado_dias" class="block text-sm font-semibold text-gray-700">Prazo Acordado (dias)</label>
+                <input
+                    type="number"
+                    id="prazo_acordado_dias"
+                    name="prazo_acordado_dias"
+                    min="1"
+                    value="<?php echo htmlspecialchars($prazo_acordado_dias); ?>"
+                    class="mt-1 block w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                >
+            </div>
+        <?php endif; ?>
 
         <div id="container_nome_responsavel">
             <label for="nome_responsavel" class="block text-sm font-semibold text-gray-700">Nome do Responsável</label>


### PR DESCRIPTION
## Summary
- adicionar o campo de Prazo Acordado ao formulário de clientes para perfis autorizados
- validar e persistir o novo prazo nos fluxos de criação e edição de clientes
- mostrar o prazo acordado no formulário de serviço rápido e preencher automaticamente os dias corridos

## Testing
- php -l app/views/clientes/form.php
- php -l app/controllers/ClientesController.php
- php -l app/models/Cliente.php
- php -l app/views/processos/form_servico_rapido.php

------
https://chatgpt.com/codex/tasks/task_e_68e09eabd8148330b196fea3bdd7c354