### PR TITLE
Normalize process notification cleanup

### DIFF
--- a/app/controllers/ProcessosController.php
+++ b/app/controllers/ProcessosController.php
@@ -1481,13 +1481,14 @@ class ProcessosController
     {
         $cliente = $this->clienteModel->getById($clienteId);
         $nomeCliente = $cliente['nome_cliente'] ?? 'Cliente';
-        $link = APP_URL . "/processos.php?action=view&id=" . $processoId;
+        $linkPath = '/processos.php?action=view&id=' . $processoId;
+        $link = $this->buildAbsoluteUrl($linkPath);
         $tipoMinusculo = mb_strtolower($tipoPendencia, 'UTF-8');
         $tipoCapitalizado = mb_convert_case($tipoMinusculo, MB_CASE_TITLE, 'UTF-8');
         $gerentesIds = $this->userModel->getIdsByPerfil(['admin', 'gerencia', 'supervisor']);
         foreach ($gerentesIds as $gerenteId) {
             $mensagem = "Novo {$tipoMinusculo} pendente para o cliente '{$nomeCliente}'.";
-            $this->notificacaoModel->criar($gerenteId, $remetenteId, $mensagem, $link);
+            $this->notificacaoModel->criar($gerenteId, $remetenteId, $mensagem, $linkPath);
             $gerente = $this->userModel->getById($gerenteId);
             if ($gerente && !empty($gerente['email'])) {
                 $subject = "{$tipoCapitalizado} pendente de aprovação";
@@ -2364,6 +2365,21 @@ class ProcessosController
     private function normalizeStatusName(?string $status): string
     {
         return mb_strtolower(trim((string)$status));
+    }
+
+    private function buildAbsoluteUrl(string $path): string
+    {
+        if (!defined('APP_URL')) {
+            return $this->ensureLeadingSlash($path);
+        }
+
+        $normalizedPath = $this->ensureLeadingSlash($path);
+        return rtrim(APP_URL, '/') . $normalizedPath;
+    }
+
+    private function ensureLeadingSlash(string $path): string
+    {
+        return '/' . ltrim($path, '/');
     }
 
     /**

--- a/docs/database_usage_examples.md
+++ b/docs/database_usage_examples.md
@@ -31,3 +31,9 @@ WHERE customerEmail = 'maria.oliveira@example.com';
 DELETE FROM customers
 WHERE statusFlag = 0;
 ```
+
+```sql
+DELETE FROM process_notifications
+WHERE processId = 42
+  AND alertStatus IN ('Approved', 'Rejected');
+```


### PR DESCRIPTION
## Summary
- normalize process notification links so database alerts are removed after approvals
- make the notification deletion logic handle both relative and absolute links
- document SQL deletion guidance for process notifications

## Testing
- php -l app/models/Notificacao.php
- php -l app/controllers/ProcessosController.php

------
https://chatgpt.com/codex/tasks/task_e_68e0a04fb5148330baa71b33963aa2f8