### PR TITLE
Ajusta layout dos botões de aprovação nas notificações

### DIFF
--- a/app/views/processos/detalhe.php
+++ b/app/views/processos/detalhe.php
@@ -58,6 +58,9 @@ switch ($statusNormalized) {
 }
 $leadConversionContext = $leadConversionContext ?? ['shouldRender' => false];
 $isAprovadoOuSuperior = !in_array($statusNormalized, ['orçamento', 'orçamento pendente', 'cancelado']);
+$isManager = in_array($_SESSION['user_perfil'] ?? '', ['admin', 'gerencia', 'supervisor'], true);
+$isBudgetPending = $statusNormalized === 'orçamento pendente';
+$isServicePending = $statusNormalized === 'serviço pendente';
 ?>
 
 
@@ -93,6 +96,49 @@ $isAprovadoOuSuperior = !in_array($statusNormalized, ['orçamento', 'orçamento 
 </div>
 
 <div id="feedback-container" class="hidden mb-4"></div>
+
+<?php if ($isManager && ($isBudgetPending || $isServicePending)): ?>
+    <div class="mb-6 bg-white shadow-lg rounded-lg p-6">
+        <div class="flex items-center justify-between border-b pb-3 mb-4">
+            <h2 class="text-xl font-semibold text-gray-700">Ações de Aprovação</h2>
+            <span class="text-sm text-gray-500">Visíveis apenas para gerência</span>
+        </div>
+        <?php if ($isBudgetPending): ?>
+            <div class="space-y-3">
+                <div class="flex flex-wrap justify-end gap-2">
+                    <a href="processos.php?action=aprovar_orcamento&id=<?= $processo['id']; ?>" class="inline-flex justify-center items-center px-4 py-2 text-sm font-semibold rounded-md bg-green-600 text-white shadow hover:bg-green-700">
+                        Aprovar orçamento
+                    </a>
+                    <form action="processos.php?action=recusar_orcamento" method="POST" class="flex flex-wrap items-center justify-end gap-2">
+                        <input type="hidden" name="id" value="<?= $processo['id']; ?>">
+                        <label for="motivo_recusa_detalhe" class="sr-only">Motivo da recusa</label>
+                        <input id="motivo_recusa_detalhe" type="text" name="motivo_recusa" class="w-full sm:w-60 px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent" placeholder="Motivo da recusa" required>
+                        <button type="submit" class="inline-flex justify-center items-center px-4 py-2 text-sm font-semibold rounded-md bg-red-600 text-white shadow hover:bg-red-700">
+                            Recusar orçamento
+                        </button>
+                    </form>
+                </div>
+            </div>
+        <?php elseif ($isServicePending): ?>
+            <div class="flex flex-wrap justify-end gap-2">
+                <form action="processos.php?action=change_status" method="POST" class="inline-flex">
+                    <input type="hidden" name="id" value="<?= $processo['id']; ?>">
+                    <input type="hidden" name="status_processo" value="Serviço em andamento">
+                    <button type="submit" class="inline-flex justify-center items-center px-4 py-2 text-sm font-semibold rounded-md bg-green-600 text-white shadow hover:bg-green-700">
+                        Aprovar serviço
+                    </button>
+                </form>
+                <form action="processos.php?action=change_status" method="POST" class="inline-flex">
+                    <input type="hidden" name="id" value="<?= $processo['id']; ?>">
+                    <input type="hidden" name="status_processo" value="Orçamento Pendente">
+                    <button type="submit" class="inline-flex justify-center items-center px-4 py-2 text-sm font-semibold rounded-md bg-yellow-600 text-white shadow hover:bg-yellow-700">
+                        Solicitar ajustes
+                    </button>
+                </form>
+            </div>
+        <?php endif; ?>
+    </div>
+<?php endif; ?>
 
 <div class="flex flex-col lg:flex-row gap-6">
 

--- a/app/views/processos/painel_notificacoes.php
+++ b/app/views/processos/painel_notificacoes.php
@@ -59,33 +59,35 @@
                                 </span>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                <div class="flex flex-col space-y-2 items-end">
+                                <div class="flex flex-col space-y-3 items-end">
                                     <a href="processos.php?action=view&id=<?= $processo['id']; ?>" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                                         Ver Detalhes
                                     </a>
                                     <?php if ($isManager && $isBudgetPending): ?>
-                                        <div class="flex flex-col space-y-2 w-full">
-                                            <a href="processos.php?action=aprovar_orcamento&id=<?= $processo['id']; ?>" class="inline-flex justify-center items-center px-4 py-2 text-sm font-semibold rounded-md bg-green-600 text-white shadow hover:bg-green-700">
-                                                Aprovar orçamento
-                                            </a>
-                                            <form action="processos.php?action=recusar_orcamento" method="POST" class="flex flex-col space-y-2">
-                                                <input type="hidden" name="id" value="<?= $processo['id']; ?>">
-                                                <input type="text" name="motivo_recusa" class="px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent" placeholder="Motivo da recusa" required>
-                                                <button type="submit" class="inline-flex justify-center items-center px-4 py-2 text-sm font-semibold rounded-md bg-red-600 text-white shadow hover:bg-red-700">
-                                                    Recusar orçamento
-                                                </button>
-                                            </form>
+                                        <div class="flex flex-col w-full space-y-2">
+                                            <div class="flex flex-wrap justify-end gap-2">
+                                                <a href="processos.php?action=aprovar_orcamento&id=<?= $processo['id']; ?>" class="inline-flex justify-center items-center px-4 py-2 text-sm font-semibold rounded-md bg-green-600 text-white shadow hover:bg-green-700">
+                                                    Aprovar orçamento
+                                                </a>
+                                                <form action="processos.php?action=recusar_orcamento" method="POST" class="flex flex-wrap items-center justify-end gap-2">
+                                                    <input type="hidden" name="id" value="<?= $processo['id']; ?>">
+                                                    <input type="text" name="motivo_recusa" class="w-full sm:w-56 px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent" placeholder="Motivo da recusa" required>
+                                                    <button type="submit" class="inline-flex justify-center items-center px-4 py-2 text-sm font-semibold rounded-md bg-red-600 text-white shadow hover:bg-red-700">
+                                                        Recusar orçamento
+                                                    </button>
+                                                </form>
+                                            </div>
                                         </div>
                                     <?php elseif ($isManager && $isServicePending): ?>
-                                        <div class="flex flex-col space-y-2 w-full">
-                                            <form action="processos.php?action=change_status" method="POST" class="flex flex-col space-y-2">
+                                        <div class="flex flex-wrap justify-end gap-2 w-full">
+                                            <form action="processos.php?action=change_status" method="POST" class="inline-flex">
                                                 <input type="hidden" name="id" value="<?= $processo['id']; ?>">
                                                 <input type="hidden" name="status_processo" value="Serviço em andamento">
                                                 <button type="submit" class="inline-flex justify-center items-center px-4 py-2 text-sm font-semibold rounded-md bg-green-600 text-white shadow hover:bg-green-700">
                                                     Aprovar serviço
                                                 </button>
                                             </form>
-                                            <form action="processos.php?action=change_status" method="POST" class="flex flex-col space-y-2">
+                                            <form action="processos.php?action=change_status" method="POST" class="inline-flex">
                                                 <input type="hidden" name="id" value="<?= $processo['id']; ?>">
                                                 <input type="hidden" name="status_processo" value="Orçamento Pendente">
                                                 <button type="submit" class="inline-flex justify-center items-center px-4 py-2 text-sm font-semibold rounded-md bg-yellow-600 text-white shadow hover:bg-yellow-700">


### PR DESCRIPTION
## Resumo
- Harmoniza a disposição dos botões de aprovação e recusa na tabela do painel de notificações
- Exibe ações de aprovação no detalhe do processo apenas para usuários de gerência, admin e supervisão

## Testes
- php -l app/views/processos/painel_notificacoes.php
- php -l app/views/processos/detalhe.php

------
https://chatgpt.com/codex/tasks/task_e_68e0a06065a88330ae272bcaa94658ec