### PR TITLE
Adicionar steps ao fluxo de conversão de orçamento

### DIFF
--- a/app/views/processos/conversao_pagamento.php
+++ b/app/views/processos/conversao_pagamento.php
@@ -28,6 +28,27 @@ $paymentDateOne = $formData['data_pagamento_1'] ?? '';
 if ($paymentDateOne === '' && ($totalValue === '' || $totalValue === null)) {
     $paymentDateOne = date('Y-m-d');
 }
+
+$conversionSteps = [
+    [
+        'key' => 'client',
+        'label' => 'Cliente',
+        'description' => 'Revise ou cadastre os dados do cliente.',
+    ],
+    [
+        'key' => 'deadline',
+        'label' => 'Prazo do serviço',
+        'description' => 'Defina data de início e prazo de entrega.',
+    ],
+    [
+        'key' => 'payment',
+        'label' => 'Pagamento',
+        'description' => 'Informe as condições financeiras.',
+    ],
+];
+$currentStep = 'payment';
+$completedSteps = ['client', 'deadline'];
+include __DIR__ . '/partials/conversion_steps.php';
 ?>
 <div class="max-w-3xl mx-auto space-y-8">
     <div class="flex items-center justify-between">

--- a/app/views/processos/conversao_prazo.php
+++ b/app/views/processos/conversao_prazo.php
@@ -2,6 +2,27 @@
 $formData = $formData ?? [];
 $processId = (int)($processo['id'] ?? 0);
 $deadlineType = $formData['traducao_prazo_tipo'] ?? 'dias';
+
+$conversionSteps = [
+    [
+        'key' => 'client',
+        'label' => 'Cliente',
+        'description' => 'Revise ou cadastre os dados do cliente.',
+    ],
+    [
+        'key' => 'deadline',
+        'label' => 'Prazo do serviço',
+        'description' => 'Defina data de início e prazo de entrega.',
+    ],
+    [
+        'key' => 'payment',
+        'label' => 'Pagamento',
+        'description' => 'Informe as condições financeiras.',
+    ],
+];
+$currentStep = 'deadline';
+$completedSteps = ['client'];
+include __DIR__ . '/partials/conversion_steps.php';
 ?>
 <div class="max-w-3xl mx-auto space-y-8">
     <div class="flex items-center justify-between">

--- a/app/views/processos/partials/conversion_steps.php
+++ b/app/views/processos/partials/conversion_steps.php
@@ -1,0 +1,73 @@
+<?php
+$profile = $_SESSION['user_perfil'] ?? '';
+if ($profile !== 'vendedor') {
+    return;
+}
+
+$stepItems = isset($conversionSteps) && is_array($conversionSteps) ? $conversionSteps : [];
+if ($stepItems === []) {
+    return;
+}
+
+$currentStepKey = isset($currentStep) ? (string)$currentStep : '';
+$completedStepKeys = isset($completedSteps) && is_array($completedSteps) ? $completedSteps : [];
+$stepCount = count($stepItems);
+?>
+<div class="mb-8">
+    <ol class="flex flex-col space-y-4 md:flex-row md:items-center md:space-y-0 md:space-x-4">
+        <?php foreach ($stepItems as $index => $stepData):
+            $stepKey = (string)($stepData['key'] ?? $index);
+            $label = (string)($stepData['label'] ?? ('Etapa ' . ($index + 1)));
+            $description = isset($stepData['description']) ? (string)$stepData['description'] : '';
+
+            $status = 'pending';
+            if (in_array($stepKey, $completedStepKeys, true)) {
+                $status = 'done';
+            } elseif ($stepKey === $currentStepKey) {
+                $status = 'current';
+            }
+
+            $indicatorClass = [
+                'done' => 'bg-green-500 text-white',
+                'current' => 'bg-orange-500 text-white',
+                'pending' => 'bg-gray-200 text-gray-600',
+            ][$status];
+
+            $labelClass = [
+                'done' => 'text-gray-800',
+                'current' => 'text-gray-800',
+                'pending' => 'text-gray-500',
+            ][$status];
+
+            $connectorClass = [
+                'done' => 'bg-green-500',
+                'current' => 'bg-orange-500',
+                'pending' => 'bg-gray-200',
+            ][$status];
+        ?>
+        <li class="flex items-center md:flex-1">
+            <div class="flex items-center">
+                <span class="flex h-9 w-9 items-center justify-center rounded-full text-sm font-semibold <?php echo $indicatorClass; ?>">
+                    <?php echo $status === 'done' ? '✓' : ($index + 1); ?>
+                </span>
+                <div class="ml-3">
+                    <p class="text-sm font-semibold <?php echo $labelClass; ?>">
+                        <?php echo htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?>
+                    </p>
+                    <?php if ($description !== ''): ?>
+                        <p class="text-xs text-gray-500"><?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?></p>
+                    <?php endif; ?>
+                </div>
+            </div>
+            <?php if ($index < $stepCount - 1): ?>
+                <div class="hidden flex-1 items-center px-4 md:flex">
+                    <span class="h-0.5 w-full rounded <?php echo $connectorClass; ?>"></span>
+                </div>
+            <?php endif; ?>
+        </li>
+        <?php endforeach; ?>
+    </ol>
+</div>
+<?php
+unset($conversionSteps, $currentStep, $completedSteps);
+?>


### PR DESCRIPTION
## Summary
- criar partial reutilizável para exibir etapas do fluxo de conversão de orçamento em serviço
- incluir o componente de etapas nas telas de definição de prazo e pagamento, destacando progresso do vendedor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a446efcc8330a79ed189c33436ed