### PR TITLE
Restringe exibição de leads conforme perfil na criação de orçamento

### DIFF
--- a/app/controllers/ProcessosController.php
+++ b/app/controllers/ProcessosController.php
@@ -2519,11 +2519,19 @@ class ProcessosController
 
     private function getClientesForOrcamentoForm(?array $processo = null): array
     {
-        $clientes = [];
-        if ($processo !== null && !$this->isBudgetStatus($processo['status_processo'] ?? null)) {
+        $userProfile = $_SESSION['user_perfil'] ?? '';
+        $userId = isset($_SESSION['user_id']) ? (int) $_SESSION['user_id'] : null;
+
+        $isEditingNonBudget = $processo !== null && !$this->isBudgetStatus($processo['status_processo'] ?? null);
+
+        if ($isEditingNonBudget) {
             $clientes = $this->clienteModel->getAll();
+        } elseif ($userProfile === 'vendedor') {
+            $clientes = $userId !== null
+                ? $this->clienteModel->getProspectsByOwner($userId)
+                : $this->clienteModel->getProspects();
         } else {
-            $clientes = $this->clienteModel->getProspects();
+            $clientes = $this->clienteModel->getAll();
         }
 
         if ($processo === null) {

--- a/app/models/Cliente.php
+++ b/app/models/Cliente.php
@@ -227,6 +227,18 @@ class Cliente
     }
 
     /**
+     * Fetch prospects filtered by the CRM owner identifier.
+     */
+    public function getProspectsByOwner(int $ownerId): array
+    {
+        $sql = 'SELECT * FROM clientes WHERE is_prospect = 1 AND crmOwnerId = :ownerId ORDER BY nome_cliente';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([':ownerId' => $ownerId]);
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
      * Busca apenas os clientes finais utilizados no sistema principal.
      *
      * @return array Lista de clientes com is_prospect = 0.


### PR DESCRIPTION
## Resumo
- limita os leads exibidos para vendedores aos registros próprios no formulário de orçamento
- mantém todos os clientes disponíveis para demais perfis ao criar ou editar um orçamento
- adiciona método dedicado para buscar prospects filtrados pelo responsável

## Testes
- php -l app/models/Cliente.php
- php -l app/controllers/ProcessosController.php

------
https://chatgpt.com/codex/tasks/task_e_68e0bda5a52c83309a889cb838ff3d60