### PR TITLE
Remover aviso de documentos de tradução ausentes

### DIFF
--- a/app/views/processos/form.php
+++ b/app/views/processos/form.php
@@ -313,8 +313,6 @@ $paymentDateTwo = $processo['data_pagamento_2'] ?? $formData['data_pagamento_2']
                             <?php endforeach; ?>
                         </ul>
                     </div>
-                <?php else: ?>
-                    <div class="rounded-md border border-blue-100 bg-white p-4 text-sm text-gray-500">Documentos para Tradução: Nenhum documento listado.</div>
                 <?php endif; ?>
             </div>
             <div class="space-y-4">


### PR DESCRIPTION
## Summary
- remove o aviso estático "Documentos para Tradução: Nenhum documento listado." do formulário de orçamento, mantendo somente a listagem quando houver anexos

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c1fea16883308995b5feb0710746