### PR TITLE
Adjusta fuso horario para America/Sao_Paulo

### DIFF
--- a/config.php
+++ b/config.php
@@ -5,6 +5,8 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
+date_default_timezone_set('America/Sao_Paulo');
+
 // 1. Configurações de Conexão com a Base de Dados
 define('DB_HOST', 'localhost');
 define('DB_NAME', 'u371107598_dadosnovalis');


### PR DESCRIPTION
## Summary
- define the application default timezone as America/Sao_Paulo to alinhar os horários exibidos com São Paulo

## Testing
- php -l config.php

------
https://chatgpt.com/codex/tasks/task_e_68e12890f2788330b4aca9f9f98fa02c