### PR TITLE
Implement asynchronous processing for external integrations

### DIFF
--- a/app/services/AsyncTaskDispatcher.php
+++ b/app/services/AsyncTaskDispatcher.php
@@ -1,0 +1,55 @@
+<?php
+
+class AsyncTaskDispatcher
+{
+    /** @var callable[] */
+    private static $tasks = [];
+
+    /** @var bool */
+    private static $registered = false;
+
+    public static function queue(callable $task): void
+    {
+        self::$tasks[] = $task;
+
+        if (!self::$registered) {
+            register_shutdown_function([self::class, 'run']);
+            self::$registered = true;
+        }
+    }
+
+    public static function run(): void
+    {
+        if (empty(self::$tasks)) {
+            return;
+        }
+
+        @ignore_user_abort(true);
+        @set_time_limit(0);
+
+        if (function_exists('fastcgi_finish_request')) {
+            @fastcgi_finish_request();
+        } else {
+            if (php_sapi_name() !== 'cli') {
+                if (ob_get_level() > 0) {
+                    @ob_flush();
+                }
+                @flush();
+            }
+        }
+
+        foreach (self::$tasks as $task) {
+            try {
+                $task();
+            } catch (\Throwable $exception) {
+                error_log('Erro ao executar tarefa assíncrona: ' . $exception->getMessage());
+            }
+        }
+
+        self::$tasks = [];
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            @session_write_close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an AsyncTaskDispatcher helper that leverages fastcgi_finish_request to run queued tasks after the response is sent
- update ProcessosController to queue Omie service order generation, management notifications, and budget emails for asynchronous execution

## Testing
- php -l app/services/AsyncTaskDispatcher.php
- php -l app/controllers/ProcessosController.php

------
https://chatgpt.com/codex/tasks/task_e_68e12e981b0483308b730ee22a29d3b1