### PR TITLE
feat: permitir importação de leads via CSV

### DIFF
--- a/app/models/User.php
+++ b/app/models/User.php
@@ -159,11 +159,24 @@ class User
         $placeholders = implode(',', array_fill(0, count($perfis), '?'));
 
         $sql = "SELECT id FROM users WHERE perfil IN ($placeholders)";
-        
+
         $stmt = $this->pdo->prepare($sql);
         $stmt->execute($perfis);
-        
+
         // Retorna um array simples de IDs, ex: [1, 5, 12]
         return $stmt->fetchAll(PDO::FETCH_COLUMN);
+    }
+
+    public function getActiveVendors(): array
+    {
+        $sql = "SELECT id, nome_completo
+                FROM users
+                WHERE perfil = 'vendedor' AND (ativo = 1 OR ativo IS NULL)
+                ORDER BY nome_completo ASC";
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute();
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 }

--- a/crm/clientes/importar.php
+++ b/crm/clientes/importar.php
@@ -1,0 +1,126 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../app/core/auth_check.php';
+require_once __DIR__ . '/../../app/models/User.php';
+
+$userModel = new User($pdo);
+
+$currentUserId = isset($_SESSION['user_id']) ? (int)$_SESSION['user_id'] : null;
+$currentUserPerfil = $_SESSION['user_perfil'] ?? '';
+
+$channelOptions = [
+    'Call',
+    'LinkedIn',
+    'Instagram',
+    'Whatsapp',
+    'Indicação Cliente',
+    'Indicação Cartório',
+    'Website',
+    'Bitrix',
+    'Evento',
+    'Outro'
+];
+
+$categoryOptions = [
+    'Entrada',
+    'Qualificado',
+    'Com Orçamento',
+    'Em Negociação',
+    'Cliente Ativo',
+    'Sem Interesse'
+];
+
+$defaultChannel = 'Outro';
+$defaultCategory = 'Entrada';
+
+$assignedOwnerId = $currentUserPerfil === 'vendedor' ? $currentUserId : null;
+$vendors = $currentUserPerfil === 'vendedor' ? [] : $userModel->getActiveVendors();
+
+$pageTitle = 'Importar Leads via CSV';
+require_once __DIR__ . '/../../app/views/layouts/header.php';
+?>
+
+<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="bg-white shadow rounded-lg p-6">
+        <h1 class="text-2xl font-bold text-gray-800 mb-6"><?php echo $pageTitle; ?></h1>
+        <form action="<?php echo APP_URL; ?>/crm/clientes/importar_processar.php" method="POST" enctype="multipart/form-data" class="space-y-6">
+            <div>
+                <label for="csv_file" class="block text-sm font-medium text-gray-700">Arquivo CSV</label>
+                <input type="file" name="csv_file" id="csv_file" accept=".csv" required class="mt-1 block w-full text-sm text-gray-700" />
+                <p class="mt-2 text-sm text-gray-500">Estrutura esperada: Nome do Lead / Empresa, Nome do Lead Principal, E-mail, Telefone.</p>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                    <label for="default_channel" class="block text-sm font-medium text-gray-700">Canal de Origem padrão</label>
+                    <select id="default_channel" name="default_channel" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+                        <?php foreach ($channelOptions as $channel): ?>
+                            <option value="<?php echo htmlspecialchars($channel); ?>" <?php echo $channel === $defaultChannel ? 'selected' : ''; ?>><?php echo htmlspecialchars($channel); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+
+                <div>
+                    <label for="default_category" class="block text-sm font-medium text-gray-700">Categoria padrão</label>
+                    <select id="default_category" name="default_category" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+                        <?php foreach ($categoryOptions as $category): ?>
+                            <option value="<?php echo htmlspecialchars($category); ?>" <?php echo $category === $defaultCategory ? 'selected' : ''; ?>><?php echo htmlspecialchars($category); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+
+                <div>
+                    <label for="delimiter" class="block text-sm font-medium text-gray-700">Delimitador</label>
+                    <select id="delimiter" name="delimiter" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+                        <option value=";">Ponto e vírgula (;)</option>
+                        <option value=",">Vírgula (,)</option>
+                    </select>
+                </div>
+
+                <div class="flex items-center pt-6">
+                    <input id="has_header" name="has_header" type="checkbox" value="1" checked class="h-4 w-4 text-blue-600 border-gray-300 rounded" />
+                    <label for="has_header" class="ml-2 block text-sm text-gray-700">Primeira linha contém cabeçalho</label>
+                </div>
+            </div>
+
+            <?php if ($currentUserPerfil === 'vendedor'): ?>
+                <input type="hidden" name="assigned_owner" value="<?php echo (int) $assignedOwnerId; ?>" />
+            <?php else: ?>
+                <div>
+                    <label for="assigned_owner" class="block text-sm font-medium text-gray-700">Responsável pelos leads</label>
+                    <select id="assigned_owner" name="assigned_owner" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+                        <option value="">Sem responsável</option>
+                        <?php foreach ($vendors as $vendor): ?>
+                            <option value="<?php echo (int) $vendor['id']; ?>"><?php echo htmlspecialchars($vendor['nome_completo']); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+            <?php endif; ?>
+
+            <div>
+                <h2 class="text-sm font-semibold text-gray-700 mb-2">Pré-visualização do cabeçalho esperado</h2>
+                <div class="overflow-x-auto">
+                    <table class="min-w-full border border-gray-200 text-sm">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-4 py-2 border border-gray-200 text-left">Nome do Lead / Empresa</th>
+                                <th class="px-4 py-2 border border-gray-200 text-left">Nome do Lead Principal</th>
+                                <th class="px-4 py-2 border border-gray-200 text-left">E-mail</th>
+                                <th class="px-4 py-2 border border-gray-200 text-left">Telefone</th>
+                            </tr>
+                        </thead>
+                    </table>
+                </div>
+            </div>
+
+            <div class="flex justify-end space-x-3">
+                <a href="<?php echo APP_URL; ?>/crm/clientes/lista.php" class="bg-gray-200 text-gray-700 font-semibold py-2 px-4 rounded-lg hover:bg-gray-300">Cancelar</a>
+                <button type="submit" class="bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-700">Importar Leads</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php
+require_once __DIR__ . '/../../app/views/layouts/footer.php';
+?>

--- a/crm/clientes/importar_processar.php
+++ b/crm/clientes/importar_processar.php
@@ -1,0 +1,193 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../app/core/auth_check.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: ' . APP_URL . '/crm/clientes/lista.php');
+    exit();
+}
+
+$currentUserId = isset($_SESSION['user_id']) ? (int)$_SESSION['user_id'] : null;
+$currentUserPerfil = $_SESSION['user_perfil'] ?? '';
+
+if (!$currentUserId) {
+    $_SESSION['error_message'] = 'Sessão expirada. Faça login novamente.';
+    header('Location: ' . APP_URL . '/login.php');
+    exit();
+}
+
+if (!isset($_FILES['csv_file']) || !is_uploaded_file($_FILES['csv_file']['tmp_name'])) {
+    $_SESSION['error_message'] = 'Nenhum arquivo foi enviado para importação.';
+    header('Location: ' . APP_URL . '/crm/clientes/importar.php');
+    exit();
+}
+
+$channelOptions = [
+    'Call',
+    'LinkedIn',
+    'Instagram',
+    'Whatsapp',
+    'Indicação Cliente',
+    'Indicação Cartório',
+    'Website',
+    'Bitrix',
+    'Evento',
+    'Outro'
+];
+
+$categoryOptions = [
+    'Entrada',
+    'Qualificado',
+    'Com Orçamento',
+    'Em Negociação',
+    'Cliente Ativo',
+    'Sem Interesse'
+];
+
+$defaultChannel = $_POST['default_channel'] ?? 'Outro';
+if (!in_array($defaultChannel, $channelOptions, true)) {
+    $defaultChannel = 'Outro';
+}
+
+$defaultCategory = $_POST['default_category'] ?? 'Entrada';
+if (!in_array($defaultCategory, $categoryOptions, true)) {
+    $defaultCategory = 'Entrada';
+}
+
+$delimiter = $_POST['delimiter'] ?? ';';
+$allowedDelimiters = [';', ',', '\t'];
+if (!in_array($delimiter, $allowedDelimiters, true)) {
+    $delimiter = ';';
+}
+
+$hasHeader = isset($_POST['has_header']);
+
+$assignedOwnerId = null;
+if ($currentUserPerfil === 'vendedor') {
+    $assignedOwnerId = $currentUserId;
+} else {
+    $assignedOwnerId = isset($_POST['assigned_owner']) && $_POST['assigned_owner'] !== ''
+        ? (int) $_POST['assigned_owner']
+        : null;
+
+    if ($assignedOwnerId) {
+        $stmtOwner = $pdo->prepare("SELECT id FROM users WHERE id = :id AND perfil = 'vendedor'");
+        $stmtOwner->execute([':id' => $assignedOwnerId]);
+        if (!$stmtOwner->fetchColumn()) {
+            $assignedOwnerId = null;
+        }
+    }
+}
+
+$filePath = $_FILES['csv_file']['tmp_name'];
+$handle = fopen($filePath, 'r');
+
+if (!$handle) {
+    $_SESSION['error_message'] = 'Não foi possível abrir o arquivo enviado.';
+    header('Location: ' . APP_URL . '/crm/clientes/importar.php');
+    exit();
+}
+
+$createdCount = 0;
+$skippedCount = 0;
+$duplicateCount = 0;
+$errorRows = [];
+$rowNumber = 0;
+
+$pdo->beginTransaction();
+
+try {
+    if ($hasHeader) {
+        fgetcsv($handle, 0, $delimiter);
+    }
+
+    $insertSql = "INSERT INTO clientes (nome_cliente, nome_responsavel, email, telefone, canal_origem, categoria, is_prospect, crmOwnerId)
+                  VALUES (:nome_cliente, :nome_responsavel, :email, :telefone, :canal_origem, :categoria, 1, :crm_owner_id)";
+    $insertStmt = $pdo->prepare($insertSql);
+
+    $duplicateSql = "SELECT id FROM clientes
+                     WHERE is_prospect = 1 AND (
+                         (:email <> '' AND email = :email) OR
+                         (:telefone <> '' AND REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(telefone, '(', ''), ')', ''), '-', ''), ' ', ''), '.', ''), '+', '') = :telefone) OR
+                         (:nome_cliente <> '' AND LOWER(nome_cliente) = LOWER(:nome_cliente))
+                     )
+                     LIMIT 1";
+    $duplicateStmt = $pdo->prepare($duplicateSql);
+
+    while (($data = fgetcsv($handle, 0, $delimiter)) !== false) {
+        $rowNumber++;
+
+        $nomeCliente = trim($data[0] ?? '');
+        $nomeResponsavel = trim($data[1] ?? '');
+        $emailRaw = trim($data[2] ?? '');
+        $telefoneRaw = trim($data[3] ?? '');
+
+        if ($nomeCliente === '' && $emailRaw === '' && $telefoneRaw === '') {
+            $skippedCount++;
+            continue;
+        }
+
+        if ($nomeCliente === '') {
+            $skippedCount++;
+            $errorRows[] = "Linha {$rowNumber}: Nome do Lead é obrigatório.";
+            continue;
+        }
+
+        $email = filter_var($emailRaw, FILTER_VALIDATE_EMAIL) ? $emailRaw : '';
+        $telefoneDigits = preg_replace('/\D+/', '', $telefoneRaw);
+
+        $duplicateStmt->execute([
+            ':email' => $email,
+            ':telefone' => $telefoneDigits,
+            ':nome_cliente' => $nomeCliente,
+        ]);
+
+        if ($duplicateStmt->fetchColumn()) {
+            $duplicateCount++;
+            continue;
+        }
+
+        $insertStmt->execute([
+            ':nome_cliente' => $nomeCliente,
+            ':nome_responsavel' => $nomeResponsavel !== '' ? $nomeResponsavel : null,
+            ':email' => $email !== '' ? $email : null,
+            ':telefone' => $telefoneRaw !== '' ? $telefoneRaw : null,
+            ':canal_origem' => $defaultChannel,
+            ':categoria' => $defaultCategory,
+            ':crm_owner_id' => $assignedOwnerId,
+        ]);
+
+        $createdCount++;
+    }
+
+    $pdo->commit();
+} catch (Throwable $exception) {
+    $pdo->rollBack();
+    fclose($handle);
+
+    error_log('Erro na importação de leads: ' . $exception->getMessage());
+    $_SESSION['error_message'] = 'Não foi possível concluir a importação. Tente novamente.';
+    header('Location: ' . APP_URL . '/crm/clientes/importar.php');
+    exit();
+}
+
+fclose($handle);
+
+$_SESSION['import_summary'] = [
+    'created' => $createdCount,
+    'skipped' => $skippedCount,
+    'duplicates' => $duplicateCount,
+    'errors' => array_slice($errorRows, 0, 5),
+];
+
+if ($createdCount > 0) {
+    $_SESSION['success_message'] = "Importação concluída: {$createdCount} lead(s) criado(s).";
+} elseif ($duplicateCount > 0) {
+    $_SESSION['success_message'] = 'Importação concluída sem novos leads. Todos já existiam.';
+} elseif (!empty($errorRows) || $skippedCount > 0) {
+    $_SESSION['error_message'] = 'Nenhum lead foi importado. Verifique o arquivo e tente novamente.';
+}
+
+header('Location: ' . APP_URL . '/crm/clientes/lista.php');
+exit();
+?>

--- a/crm/clientes/lista.php
+++ b/crm/clientes/lista.php
@@ -19,12 +19,18 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
 
-    <div class="flex justify-between items-center mb-6">
+    <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center mb-6 gap-4">
         <h1 class="text-3xl font-bold text-gray-800"><?php echo $pageTitle; ?></h1>
-        <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php" class="bg-blue-600 text-white py-2 px-4 rounded-md shadow-md hover:bg-blue-700 transition duration-300 flex items-center">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" /></svg>
-            Novo Lead
-        </a>
+        <div class="flex flex-col sm:flex-row gap-3">
+            <a href="<?php echo APP_URL; ?>/crm/clientes/importar.php" class="bg-green-600 text-white py-2 px-4 rounded-md shadow-md hover:bg-green-700 transition duration-300 flex items-center justify-center">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
+                Importar Leads
+            </a>
+            <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php" class="bg-blue-600 text-white py-2 px-4 rounded-md shadow-md hover:bg-blue-700 transition duration-300 flex items-center justify-center">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" /></svg>
+                Novo Lead
+            </a>
+        </div>
     </div>
 
     <?php if (isset($_SESSION['success_message'])): ?>
@@ -35,6 +41,27 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
     <?php if (isset($_SESSION['error_message'])): ?>
         <div class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-6" role="alert">
             <p><?php echo $_SESSION['error_message']; unset($_SESSION['error_message']); ?></p>
+        </div>
+    <?php endif; ?>
+    <?php if (isset($_SESSION['import_summary'])): ?>
+        <?php $summary = $_SESSION['import_summary']; unset($_SESSION['import_summary']); ?>
+        <div class="bg-blue-50 border-l-4 border-blue-500 text-blue-700 p-4 mb-6">
+            <p class="font-semibold">Resumo da importação</p>
+            <ul class="mt-2 text-sm list-disc list-inside space-y-1">
+                <li>Leads criados: <?php echo (int)($summary['created'] ?? 0); ?></li>
+                <li>Linhas ignoradas: <?php echo (int)($summary['skipped'] ?? 0); ?></li>
+                <li>Registros duplicados: <?php echo (int)($summary['duplicates'] ?? 0); ?></li>
+            </ul>
+            <?php if (!empty($summary['errors'])): ?>
+                <div class="mt-3 text-sm">
+                    <p class="font-semibold">Ocorrências:</p>
+                    <ul class="list-disc list-inside space-y-1">
+                        <?php foreach ($summary['errors'] as $errorMessage): ?>
+                            <li><?php echo htmlspecialchars($errorMessage); ?></li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            <?php endif; ?>
         </div>
     <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- adiciona uma tela para importar leads via CSV com ajustes de canal, categoria e responsável
- cria rotina de processamento que valida linhas, evita duplicados e mantém os leads restritos ao vendedor
- expõe listagem de vendedores ativos e mostra resumo da importação na listagem de leads

## Testing
- php -l app/models/User.php
- php -l crm/clientes/importar.php
- php -l crm/clientes/importar_processar.php
- php -l crm/clientes/lista.php

------
https://chatgpt.com/codex/tasks/task_e_68e144b95fd08330807994e0cce014e1