### PR TITLE
Add TV dashboard with live refresh

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -37,6 +37,18 @@ switch ($action) {
     case 'saveSettings':
         $adminController->saveSettings();
         break;
+    case 'tv_panel':
+        $adminController->showTvPanel();
+        break;
+    case 'tv_panel_config':
+        $adminController->showTvPanelConfig();
+        break;
+    case 'save_tv_panel_config':
+        $adminController->saveTvPanelConfig();
+        break;
+    case 'tv_panel_data':
+        $adminController->getTvPanelData();
+        break;
 
     // Rota para a nova página de configurações da Omie
     case 'omie_settings':

--- a/app/utils/DashboardProcessFormatter.php
+++ b/app/utils/DashboardProcessFormatter.php
@@ -1,0 +1,216 @@
+<?php
+class DashboardProcessFormatter
+{
+    public const SETTINGS_KEY = 'tv_panel_settings';
+
+    private const DEFAULT_COLORS = [
+        'overdue' => 'bg-red-200 text-red-800',
+        'due_today' => 'bg-red-200 text-red-800',
+        'due_soon' => 'bg-yellow-200 text-yellow-800',
+        'on_track' => 'text-green-600',
+        'completed' => 'bg-green-100 text-green-800',
+        'inactive' => 'text-gray-500',
+        'no_deadline' => 'text-gray-500',
+    ];
+
+    public static function normalizeStatusInfo(?string $status): array
+    {
+        $normalized = mb_strtolower(trim((string) $status));
+
+        if ($normalized === '') {
+            return ['normalized' => '', 'label' => 'N/A'];
+        }
+
+        $aliases = [
+            'orcamento' => 'orçamento',
+            'orcamento pendente' => 'orçamento pendente',
+            'serviço pendente' => 'serviço pendente',
+            'servico pendente' => 'serviço pendente',
+            'pendente' => 'serviço pendente',
+            'aprovado' => 'serviço pendente',
+            'serviço em andamento' => 'serviço em andamento',
+            'servico em andamento' => 'serviço em andamento',
+            'em andamento' => 'serviço em andamento',
+            'finalizado' => 'concluído',
+            'finalizada' => 'concluído',
+            'concluido' => 'concluído',
+            'concluida' => 'concluído',
+            'arquivado' => 'cancelado',
+            'arquivada' => 'cancelado',
+            'recusado' => 'cancelado',
+            'recusada' => 'cancelado',
+        ];
+
+        if (isset($aliases[$normalized])) {
+            $normalized = $aliases[$normalized];
+        }
+
+        $labels = [
+            'orçamento' => 'Orçamento',
+            'orçamento pendente' => 'Orçamento Pendente',
+            'serviço pendente' => 'Serviço Pendente',
+            'serviço em andamento' => 'Serviço em Andamento',
+            'concluído' => 'Concluído',
+            'cancelado' => 'Cancelado',
+        ];
+
+        $label = $labels[$normalized] ?? ($status === '' ? 'N/A' : $status);
+
+        return ['normalized' => $normalized, 'label' => $label];
+    }
+
+    public static function getRowClass(string $statusNormalized): string
+    {
+        return match ($statusNormalized) {
+            'orçamento', 'orçamento pendente' => 'bg-blue-50 hover:bg-blue-100',
+            'serviço pendente' => 'bg-orange-50 hover:bg-orange-100',
+            'serviço em andamento' => 'bg-cyan-50 hover:bg-cyan-100',
+            'concluído' => 'bg-purple-50 hover:bg-purple-100',
+            'cancelado' => 'bg-red-50 hover:bg-red-100',
+            default => 'hover:bg-gray-50',
+        };
+    }
+
+    public static function buildDeadlineDescriptor(array $process, array $colors = []): array
+    {
+        $colors = array_merge(self::DEFAULT_COLORS, $colors);
+        $statusInfo = self::normalizeStatusInfo($process['status_processo'] ?? '');
+        $statusNormalized = $statusInfo['normalized'];
+
+        $descriptor = [
+            'label' => 'A definir',
+            'class' => $colors['no_deadline'],
+            'state' => 'no_deadline',
+            'days' => null,
+            'progress' => null,
+            'deadlineDate' => null,
+        ];
+
+        if ($statusNormalized === 'concluído') {
+            $finalizacaoTipo = $process['finalizacao_tipo'] ?? 'Cliente';
+            $descriptor['label'] = 'Concluído para ' . $finalizacaoTipo;
+            $descriptor['class'] = $colors['completed'];
+            $descriptor['state'] = 'completed';
+            return $descriptor;
+        }
+
+        if (in_array($statusNormalized, ['cancelado', 'orçamento', 'orçamento pendente'], true)) {
+            $descriptor['label'] = 'N/A';
+            $descriptor['class'] = $colors['inactive'];
+            $descriptor['state'] = 'inactive';
+            return $descriptor;
+        }
+
+        $deadlineDate = self::extractDeadlineDate($process);
+        if ($deadlineDate === null) {
+            return $descriptor;
+        }
+
+        $descriptor['deadlineDate'] = $deadlineDate;
+
+        $today = new DateTimeImmutable('today');
+        $diff = $today->diff($deadlineDate);
+        $daysRemaining = (int) $diff->format('%r%a');
+        $descriptor['days'] = $daysRemaining;
+
+        if ($daysRemaining < 0) {
+            $descriptor['label'] = abs($daysRemaining) . ' dia(s) vencido(s)';
+            $descriptor['class'] = $colors['overdue'];
+            $descriptor['state'] = 'overdue';
+        } elseif ($daysRemaining === 0) {
+            $descriptor['label'] = 'Vence hoje';
+            $descriptor['class'] = $colors['due_today'];
+            $descriptor['state'] = 'due_today';
+        } elseif ($daysRemaining <= 3) {
+            $descriptor['label'] = $daysRemaining . ' dias';
+            $descriptor['class'] = $colors['due_soon'];
+            $descriptor['state'] = 'due_soon';
+        } else {
+            $descriptor['label'] = $daysRemaining . ' dias';
+            $descriptor['class'] = $colors['on_track'];
+            $descriptor['state'] = 'on_track';
+        }
+
+        $progress = self::calculateProgressPercentage($process, $deadlineDate);
+        $descriptor['progress'] = $progress;
+
+        return $descriptor;
+    }
+
+    public static function getServiceBadges(?string $services): array
+    {
+        $map = [
+            'Tradução' => ['label' => 'Trad.', 'class' => 'bg-blue-100 text-blue-800'],
+            'CRC' => ['label' => 'CRC', 'class' => 'bg-teal-100 text-teal-800'],
+            'Apostilamento' => ['label' => 'Apost.', 'class' => 'bg-purple-100 text-purple-800'],
+            'Postagem' => ['label' => 'Post.', 'class' => 'bg-orange-100 text-orange-800'],
+        ];
+
+        $badges = [];
+        $servicesList = array_filter(array_map('trim', explode(',', (string) $services)));
+
+        foreach ($servicesList as $service) {
+            if (isset($map[$service])) {
+                $badges[] = $map[$service];
+            }
+        }
+
+        return $badges;
+    }
+
+    public static function extractDeadlineDate(array $process): ?DateTimeImmutable
+    {
+        if (!empty($process['traducao_prazo_data'])) {
+            return self::createImmutableDate($process['traducao_prazo_data']);
+        }
+
+        if (!empty($process['traducao_prazo_dias']) && !empty($process['data_inicio_traducao'])) {
+            $start = self::createImmutableDate($process['data_inicio_traducao']);
+            if ($start !== null) {
+                return $start->modify('+' . (int) $process['traducao_prazo_dias'] . ' days');
+            }
+        }
+
+        if (!empty($process['data_previsao_entrega'])) {
+            return self::createImmutableDate($process['data_previsao_entrega']);
+        }
+
+        return null;
+    }
+
+    private static function calculateProgressPercentage(array $process, DateTimeImmutable $deadline): ?int
+    {
+        $start = null;
+        if (!empty($process['data_inicio_traducao'])) {
+            $start = self::createImmutableDate($process['data_inicio_traducao']);
+        }
+
+        if ($start === null && !empty($process['data_criacao'])) {
+            $start = self::createImmutableDate($process['data_criacao']);
+        }
+
+        if ($start === null) {
+            return null;
+        }
+
+        $now = new DateTimeImmutable();
+        $total = $deadline->getTimestamp() - $start->getTimestamp();
+
+        if ($total <= 0) {
+            return null;
+        }
+
+        $elapsed = $now->getTimestamp() - $start->getTimestamp();
+        $progress = (int) round(($elapsed / $total) * 100);
+        return max(0, min(100, $progress));
+    }
+
+    private static function createImmutableDate(string $value): ?DateTimeImmutable
+    {
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception $exception) {
+            return null;
+        }
+    }
+}

--- a/app/views/admin/dashboard.php
+++ b/app/views/admin/dashboard.php
@@ -68,6 +68,15 @@ require_once __DIR__ . '/../layouts/header.php';
             <i class="fas fa-boxes text-sky-200 text-5xl"></i>
         </div>
     </a>
+    <a href="admin.php?action=tv_panel" class="bg-white p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow flex flex-col justify-between">
+        <div>
+            <h3 class="text-xl font-bold text-rose-600">Painel de TV</h3>
+            <p class="text-gray-600 mt-2">Visualize todos os processos em tela cheia para monitores corporativos.</p>
+        </div>
+        <div class="text-right mt-4">
+            <i class="fas fa-tv text-rose-200 text-5xl"></i>
+        </div>
+    </a>
     <a href="admin.php?action=smtp_settings" class="bg-white p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow flex flex-col justify-between">
         <div>
             <h3 class="text-xl font-bold text-red-500">E-mails de Notificação</h3>

--- a/app/views/admin/tv_painel.php
+++ b/app/views/admin/tv_painel.php
@@ -1,0 +1,62 @@
+<?php
+$orientationClass = $orientationClass ?? 'tv-panel-portrait';
+$refreshInterval = $settings['refresh_interval'] ?? 60;
+$progressEnabled = !empty($settings['enable_progress_bar']);
+$alertEnabled = !empty($settings['enable_alert_pulse']);
+$processesForPartial = $processes ?? [];
+$tvEndpoint = APP_URL . '/admin.php?action=tv_panel_data';
+$colorConfig = [
+    'overdue' => $settings['overdue_color'] ?? 'bg-red-200 text-red-800',
+    'due_today' => $settings['due_today_color'] ?? 'bg-red-200 text-red-800',
+    'due_soon' => $settings['due_soon_color'] ?? 'bg-yellow-200 text-yellow-800',
+    'on_track' => $settings['on_track_color'] ?? 'text-green-600',
+];
+?>
+<div class="tv-panel-container <?php echo htmlspecialchars($orientationClass); ?>" data-tv-panel
+     data-endpoint="<?php echo htmlspecialchars($tvEndpoint); ?>"
+     data-refresh-interval="<?php echo (int) $refreshInterval; ?>"
+     data-progress-enabled="<?php echo $progressEnabled ? '1' : '0'; ?>"
+     data-alert-enabled="<?php echo $alertEnabled ? '1' : '0'; ?>">
+    <header class="tv-panel-header">
+        <div class="tv-panel-title">
+            <h1 class="text-4xl font-extrabold tracking-wide">Painel Operacional</h1>
+            <p class="text-lg opacity-80">Monitoramento em tempo real dos processos ativos</p>
+        </div>
+        <div class="tv-panel-meta">
+            <div class="tv-panel-clock" data-tv-clock></div>
+            <a href="<?php echo APP_URL; ?>/admin.php?action=tv_panel_config" class="tv-panel-config-link">
+                <i class="fas fa-sliders-h mr-2"></i>Configurações
+            </a>
+        </div>
+    </header>
+
+    <section class="tv-panel-table-wrapper">
+        <?php if (empty($processesForPartial)): ?>
+            <div class="tv-panel-empty">Nenhum processo disponível no momento.</div>
+        <?php else: ?>
+            <?php
+                $processes = $processesForPartial;
+                $showActions = false;
+                $showProgress = $progressEnabled;
+                $highlightAnimations = $alertEnabled;
+                $deadlineColors = $colorConfig;
+                $allowLinks = false;
+                require __DIR__ . '/../dashboard/partials/process_table.php';
+            ?>
+        <?php endif; ?>
+    </section>
+
+    <footer class="tv-panel-footer">
+        <div>
+            <span class="font-semibold">Atualização automática:</span> a cada <span data-tv-interval><?php echo (int) ($refreshInterval / 60); ?></span> minuto(s)
+        </div>
+        <div>
+            <span class="font-semibold">Última atualização:</span> <span data-tv-last-update>Carregando...</span>
+        </div>
+        <div>
+            <span class="font-semibold">Total de processos:</span> <span data-tv-total><?php echo count($processesForPartial ?? []); ?></span>
+        </div>
+    </footer>
+</div>
+
+<script src="<?php echo APP_URL; ?>/assets/js/tv-panel.js"></script>

--- a/app/views/admin/tv_painel_config.php
+++ b/app/views/admin/tv_painel_config.php
@@ -1,0 +1,71 @@
+<div class="max-w-5xl mx-auto bg-white rounded-xl shadow-lg p-8">
+    <header class="mb-8">
+        <h1 class="text-3xl font-bold text-gray-800 mb-2">Configurações do Painel de TV</h1>
+        <p class="text-gray-600">Personalize as cores, o intervalo de atualização e o formato do painel exibido nos monitores.</p>
+    </header>
+
+    <form action="<?php echo APP_URL; ?>/admin.php?action=save_tv_panel_config" method="POST" class="space-y-8">
+        <section>
+            <h2 class="text-xl font-semibold text-gray-700 mb-4">Cores por prazo</h2>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                    <label for="overdue_color" class="block text-sm font-medium text-gray-700 mb-1">Processos atrasados</label>
+                    <input type="text" id="overdue_color" name="overdue_color" value="<?php echo htmlspecialchars($settings['overdue_color']); ?>" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Ex.: bg-red-200 text-red-800" required>
+                </div>
+                <div>
+                    <label for="due_today_color" class="block text-sm font-medium text-gray-700 mb-1">Vencimento hoje</label>
+                    <input type="text" id="due_today_color" name="due_today_color" value="<?php echo htmlspecialchars($settings['due_today_color']); ?>" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" required>
+                </div>
+                <div>
+                    <label for="due_soon_color" class="block text-sm font-medium text-gray-700 mb-1">Vence em até 3 dias</label>
+                    <input type="text" id="due_soon_color" name="due_soon_color" value="<?php echo htmlspecialchars($settings['due_soon_color']); ?>" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" required>
+                </div>
+                <div>
+                    <label for="on_track_color" class="block text-sm font-medium text-gray-700 mb-1">Prazos confortáveis</label>
+                    <input type="text" id="on_track_color" name="on_track_color" value="<?php echo htmlspecialchars($settings['on_track_color']); ?>" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" required>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <h2 class="text-xl font-semibold text-gray-700 mb-4">Atualização automática</h2>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 items-center">
+                <div>
+                    <label for="refresh_interval" class="block text-sm font-medium text-gray-700 mb-1">Intervalo padrão</label>
+                    <select id="refresh_interval" name="refresh_interval" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        <?php $options = [60 => '1 minuto', 180 => '3 minutos', 300 => '5 minutos']; ?>
+                        <?php foreach ($options as $value => $label): ?>
+                            <option value="<?php echo $value; ?>" <?php echo ((int) $settings['refresh_interval'] === $value) ? 'selected' : ''; ?>><?php echo $label; ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div>
+                    <label for="orientation" class="block text-sm font-medium text-gray-700 mb-1">Orientação do monitor</label>
+                    <select id="orientation" name="orientation" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        <option value="portrait" <?php echo ($settings['orientation'] === 'portrait') ? 'selected' : ''; ?>>Retrato (9×16)</option>
+                        <option value="landscape" <?php echo ($settings['orientation'] === 'landscape') ? 'selected' : ''; ?>>Paisagem (16×9)</option>
+                    </select>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <h2 class="text-xl font-semibold text-gray-700 mb-4">Recursos visuais</h2>
+            <div class="space-y-4">
+                <label class="inline-flex items-center">
+                    <input type="checkbox" name="enable_progress_bar" class="h-5 w-5 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500" <?php echo !empty($settings['enable_progress_bar']) ? 'checked' : ''; ?>>
+                    <span class="ml-3 text-sm text-gray-700">Exibir barra de progresso por prazo</span>
+                </label>
+                <label class="inline-flex items-center">
+                    <input type="checkbox" name="enable_alert_pulse" class="h-5 w-5 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500" <?php echo !empty($settings['enable_alert_pulse']) ? 'checked' : ''; ?>>
+                    <span class="ml-3 text-sm text-gray-700">Ativar destaque animado para prazos críticos</span>
+                </label>
+            </div>
+        </section>
+
+        <div class="flex justify-end space-x-4">
+            <a href="<?php echo APP_URL; ?>/admin.php?action=tv_panel" class="px-6 py-3 rounded-lg border border-gray-300 text-gray-700 hover:text-gray-900 hover:border-gray-400">Ver painel</a>
+            <button type="submit" class="px-6 py-3 rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700">Salvar configurações</button>
+        </div>
+    </form>
+</div>

--- a/app/views/dashboard/partials/process_table.php
+++ b/app/views/dashboard/partials/process_table.php
@@ -1,0 +1,30 @@
+<?php
+$showActions = $showActions ?? true;
+$showProgress = $showProgress ?? false;
+$highlightAnimations = $highlightAnimations ?? false;
+$deadlineColors = $deadlineColors ?? [];
+?>
+<table class="min-w-full divide-y divide-gray-200 table-auto">
+    <thead class="bg-gray-50 sticky top-0 z-10">
+        <tr>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Família</th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Assessoria</th>
+            <th scope="col" class="px-3 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Doc.</th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">OS Omie</th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Serviços</th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Entrada</th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Envio</th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Prazo</th>
+            <?php if ($showActions): ?>
+                <th scope="col" class="relative px-3 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
+            <?php endif; ?>
+        </tr>
+    </thead>
+    <tbody class="bg-white divide-y divide-gray-200" id="processes-table-body">
+        <?php
+            $processes = $processes ?? [];
+            $renderOnlyBody = false;
+            require __DIR__ . '/process_table_rows.php';
+        ?>
+    </tbody>
+</table>

--- a/app/views/dashboard/partials/process_table_rows.php
+++ b/app/views/dashboard/partials/process_table_rows.php
@@ -1,0 +1,104 @@
+<?php
+require_once __DIR__ . '/../../../utils/DashboardProcessFormatter.php';
+
+$deadlineColors = $deadlineColors ?? [];
+$showActions = $showActions ?? true;
+$showProgress = $showProgress ?? false;
+$highlightAnimations = $highlightAnimations ?? false;
+$allowLinks = $allowLinks ?? true;
+
+foreach ($processes as $processo):
+    $statusInfo = DashboardProcessFormatter::normalizeStatusInfo($processo['status_processo'] ?? '');
+    $statusNormalized = $statusInfo['normalized'];
+    $rowClass = DashboardProcessFormatter::getRowClass($statusNormalized);
+    $deadlineDescriptor = DashboardProcessFormatter::buildDeadlineDescriptor($processo, $deadlineColors);
+    $serviceBadges = DashboardProcessFormatter::getServiceBadges($processo['categorias_servico'] ?? '');
+    $deadlineClass = $deadlineDescriptor['class'];
+    $deadlineLabel = $deadlineDescriptor['label'];
+    $progressValue = $deadlineDescriptor['progress'];
+    $rowHighlight = '';
+
+    if ($highlightAnimations && in_array($deadlineDescriptor['state'], ['overdue', 'due_today'], true)) {
+        $rowHighlight = 'animate-pulse';
+    }
+?>
+<tr class="<?php echo trim($rowClass . ' ' . $rowHighlight); ?>" data-process-id="<?php echo (int) ($processo['id'] ?? 0); ?>">
+    <td class="px-3 py-1 whitespace-nowrap text-xs font-medium">
+        <?php
+            $fullTitle = htmlspecialchars(mb_strtoupper($processo['titulo'] ?? 'N/A'));
+            $shortTitle = htmlspecialchars(mb_strtoupper(mb_strimwidth($processo['titulo'] ?? 'N/A', 0, 25, '...')));
+        ?>
+        <?php if ($allowLinks): ?>
+            <a href="processos.php?action=view&id=<?php echo (int) ($processo['id'] ?? 0); ?>" class="text-blue-600 hover:text-blue-800 hover:underline truncate block" title="<?php echo $fullTitle; ?>">
+                <?php echo $shortTitle; ?>
+            </a>
+        <?php else: ?>
+            <span class="block truncate" title="<?php echo $fullTitle; ?>"><?php echo $shortTitle; ?></span>
+        <?php endif; ?>
+    </td>
+    <td class="px-3 py-1 whitespace-nowrap text-xs text-gray-500 truncate" title="<?php echo htmlspecialchars(mb_strtoupper($processo['nome_cliente'] ?? 'N/A')); ?>">
+        <?php echo htmlspecialchars(mb_strtoupper(mb_strimwidth($processo['nome_cliente'] ?? 'N/A', 0, 20, '...'))); ?>
+    </td>
+    <td class="px-3 py-1 whitespace-nowrap text-xs text-gray-500 text-center">
+        <?php echo (int) ($processo['total_documentos_soma'] ?? 0); ?>
+    </td>
+    <td class="px-3 py-1 whitespace-nowrap text-xs text-gray-500">
+        <?php
+            $osOmie = $processo['os_numero_omie'] ?? null;
+            $formattedOmie = $osOmie ? substr((string) $osOmie, -5) : 'Aguardando Omie';
+            echo htmlspecialchars($formattedOmie);
+        ?>
+    </td>
+    <td class="px-3 py-1 whitespace-nowrap text-xs text-gray-500">
+        <?php foreach ($serviceBadges as $badge): ?>
+            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full <?php echo $badge['class']; ?> mr-1"><?php echo $badge['label']; ?></span>
+        <?php endforeach; ?>
+    </td>
+    <td class="px-3 py-1 whitespace-nowrap text-xs text-gray-500">
+        <?php echo !empty($processo['data_criacao']) ? date('d/m/Y', strtotime($processo['data_criacao'])) : 'N/A'; ?>
+    </td>
+    <td class="px-3 py-1 whitespace-nowrap text-xs text-gray-500">
+        <?php echo !empty($processo['data_inicio_traducao']) ? date('d/m/Y', strtotime($processo['data_inicio_traducao'])) : 'N/A'; ?>
+    </td>
+    <td class="px-3 py-1 whitespace-nowrap text-xs font-medium">
+        <span class="px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full <?php echo $deadlineClass; ?>">
+            <?php echo htmlspecialchars($deadlineLabel); ?>
+        </span>
+        <?php if ($showProgress && $progressValue !== null): ?>
+            <div class="mt-1 h-2 bg-slate-200 rounded-full overflow-hidden">
+                <div class="h-2 bg-slate-500" style="width: <?php echo $progressValue; ?>%"></div>
+            </div>
+        <?php endif; ?>
+    </td>
+    <?php if ($showActions): ?>
+    <td class="px-3 py-1 whitespace-nowrap text-center text-xs font-medium">
+        <div class="relative inline-block p-1">
+            <svg class="w-6 h-6 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                 data-tooltip-trigger data-process-id="<?php echo (int) ($processo['id'] ?? 0); ?>"
+                 data-tooltip-content-json='<?php
+                    $statusAssinaturaTexto = 'Pendente';
+                    $statusAssinaturaClasse = 'bg-yellow-100 text-yellow-800';
+                    if (!empty($processo['data_devolucao_assinatura'])) {
+                        $statusAssinaturaTexto = 'Enviado';
+                        $statusAssinaturaClasse = 'bg-green-100 text-green-800';
+                    }
+                    $nomeTradutor = htmlspecialchars($processo['nome_tradutor'] ?? 'Não definido', ENT_QUOTES, 'UTF-8');
+                    $modalidadeTraducao = htmlspecialchars($processo['traducao_modalidade'] ?? 'N/A', ENT_QUOTES, 'UTF-8');
+                    $envioCartorio = !empty($processo['data_envio_cartorio']) ? date('d/m/Y', strtotime($processo['data_envio_cartorio'])) : 'Pendente';
+                    $tooltipHtml = '<div class="space-y-1 text-left whitespace-nowrap">'
+                        . '<div><span class="font-semibold">Tradutor:</span> ' . $nomeTradutor . '</div>'
+                        . '<div><span class="font-semibold">Modalidade:</span> ' . $modalidadeTraducao . '</div>'
+                        . '<div><span class="font-semibold">Assinatura:</span> <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full '
+                        . $statusAssinaturaClasse . '">' . $statusAssinaturaTexto . '</span></div>'
+                        . '<div><span class="font-semibold">Envio Cartório:</span> ' . $envioCartorio . '</div>'
+                        . '</div>';
+                    echo $tooltipHtml;
+                 ?>'>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                      d="M13 16h-1v-4h-1m1-4h.01M12 18.5a6.5 6.5 0 110-13 6.5 6.5 0 010 13z" />
+            </svg>
+        </div>
+    </td>
+    <?php endif; ?>
+</tr>
+<?php endforeach; ?>

--- a/app/views/layouts/header.php
+++ b/app/views/layouts/header.php
@@ -14,6 +14,7 @@ $notificacaoModel = new Notificacao($pdo);
 
 $theme_color = $configModel->get('theme_color');
 $system_logo = $configModel->get('system_logo');
+$bodyClass = isset($bodyClass) ? trim($bodyClass) : 'bg-slate-100 text-slate-800';
 
 // --- LÓGICA DE PERMISSÕES ---
 $user_perfil = $_SESSION['user_perfil'] ?? 'guest';
@@ -94,7 +95,7 @@ if ($is_vendedor && $currentPage === 'dashboard.php') {
     </style>
 
 </head>
-<body class="bg-slate-100 text-slate-800">
+<body class="<?php echo htmlspecialchars($bodyClass); ?>">
     <nav class="bg-white shadow-md border-b-4 border-theme-color">
         <div class="max-w-[95%] mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16">

--- a/assets/js/tv-panel.js
+++ b/assets/js/tv-panel.js
@@ -1,0 +1,86 @@
+(function () {
+    document.addEventListener('DOMContentLoaded', () => {
+        const container = document.querySelector('[data-tv-panel]');
+        if (!container) {
+            return;
+        }
+
+        const endpoint = container.dataset.endpoint;
+        const refreshInterval = parseInt(container.dataset.refreshInterval, 10) || 60;
+        const tableBody = container.querySelector('#processes-table-body');
+        const clockDisplay = container.querySelector('[data-tv-clock]');
+        const lastUpdateDisplay = container.querySelector('[data-tv-last-update]');
+        const totalDisplay = container.querySelector('[data-tv-total]');
+        const intervalDisplay = container.querySelector('[data-tv-interval]');
+
+        if (intervalDisplay) {
+            intervalDisplay.textContent = Math.max(1, Math.round(refreshInterval / 60));
+        }
+
+        const formatDateTime = (date) => {
+            return new Intl.DateTimeFormat('pt-BR', {
+                day: '2-digit',
+                month: '2-digit',
+                year: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit'
+            }).format(date);
+        };
+
+        const updateClock = () => {
+            if (clockDisplay) {
+                clockDisplay.textContent = formatDateTime(new Date());
+            }
+        };
+
+        updateClock();
+        setInterval(updateClock, 1000);
+
+        const updateLastUpdate = (timestamp) => {
+            if (!lastUpdateDisplay) {
+                return;
+            }
+
+            const parsedDate = timestamp ? new Date(timestamp) : new Date();
+            if (Number.isNaN(parsedDate.getTime())) {
+                lastUpdateDisplay.textContent = '—';
+                return;
+            }
+
+            lastUpdateDisplay.textContent = formatDateTime(parsedDate);
+        };
+
+        const refreshTable = () => {
+            if (!endpoint || !tableBody) {
+                return;
+            }
+
+            fetch(endpoint, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            })
+                .then((response) => response.json())
+                .then((data) => {
+                    if (!data || data.success !== true) {
+                        return;
+                    }
+
+                    if (typeof data.html === 'string') {
+                        tableBody.innerHTML = data.html;
+                    }
+
+                    if (totalDisplay && typeof data.total === 'number') {
+                        totalDisplay.textContent = data.total;
+                    }
+
+                    updateLastUpdate(data.generated_at);
+                })
+                .catch(() => {
+                    updateLastUpdate(null);
+                });
+        };
+
+        refreshTable();
+        setInterval(refreshTable, refreshInterval * 1000);
+    });
+})();

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,122 @@
+.tv-panel-page nav {
+    display: none;
+}
+
+.tv-panel-page main {
+    max-width: 100%;
+    padding: 2rem 3rem;
+    min-height: 100vh;
+}
+
+.tv-panel-page main > div {
+    padding: 0;
+}
+
+.tv-panel-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    min-height: calc(100vh - 4rem);
+}
+
+.tv-panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    color: #f8fafc;
+}
+
+.tv-panel-title h1 {
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.tv-panel-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+}
+
+.tv-panel-clock {
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.tv-panel-config-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 9999px;
+    background: rgba(15, 23, 42, 0.4);
+    color: #f8fafc;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.3s ease;
+}
+
+.tv-panel-config-link:hover {
+    background: rgba(148, 163, 184, 0.4);
+}
+
+.tv-panel-table-wrapper {
+    flex: 1;
+    overflow: hidden;
+    border-radius: 1rem;
+    background: rgba(15, 23, 42, 0.35);
+    padding: 1rem;
+}
+
+.tv-panel-table-wrapper table {
+    width: 100%;
+    font-size: 1.05rem;
+    color: #0f172a;
+}
+
+.tv-panel-table-wrapper th,
+.tv-panel-table-wrapper td {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+}
+
+.tv-panel-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: #cbd5f5;
+    font-size: 1rem;
+}
+
+.tv-panel-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    font-size: 2rem;
+    color: #e2e8f0;
+}
+
+.tv-panel-portrait {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.tv-panel-landscape {
+    max-width: 1600px;
+    margin: 0 auto;
+}
+
+.tv-panel-page .min-w-full tbody tr td,
+.tv-panel-page .min-w-full thead th {
+    font-size: 1rem;
+}
+
+.tv-panel-page .min-w-full thead th {
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.tv-panel-page .min-w-full tbody tr td span {
+    font-size: 0.95rem;
+}


### PR DESCRIPTION
## Summary
- extract the dashboard process table into shared helpers/partials for reuse
- add a full-screen TV dashboard with automatic refresh and configurable colors/intervals
- extend the admin area with TV panel routing, configuration UI, and supporting assets/styles

## Testing
- php -l app/controllers/AdminController.php
- php -l admin.php
- php -l app/models/Processo.php

------
https://chatgpt.com/codex/tasks/task_e_68e1b23dd0388330b1c7151170f6954c