### PR TITLE
Padroniza layout das telas do CRM

### DIFF
--- a/app/views/layouts/crm_end.php
+++ b/app/views/layouts/crm_end.php
@@ -1,0 +1,2 @@
+</main>
+<?php require __DIR__ . '/footer.php'; ?>

--- a/app/views/layouts/crm_start.php
+++ b/app/views/layouts/crm_start.php
@@ -1,0 +1,5 @@
+<?php
+$bodyClass = trim(($bodyClass ?? '') . ' crm-layout');
+require __DIR__ . '/header.php';
+?>
+<main class="crm-shell">

--- a/app/views/layouts/header.php
+++ b/app/views/layouts/header.php
@@ -94,9 +94,17 @@ if ($is_vendedor && $currentPage === 'dashboard.php') {
     </style>
 
 </head>
-<body class="bg-slate-100 text-slate-800">
+<?php
+$defaultBodyClass = 'bg-slate-100 text-slate-800';
+$extraBodyClass = $bodyClass ?? '';
+if (strpos($_SERVER['PHP_SELF'] ?? '', '/crm/') !== false && strpos($extraBodyClass, 'crm-layout') === false) {
+    $extraBodyClass = trim($extraBodyClass . ' crm-layout');
+}
+$bodyClassList = trim($defaultBodyClass . ' ' . $extraBodyClass);
+?>
+<body class="<?php echo htmlspecialchars($bodyClassList); ?>">
     <nav class="bg-white shadow-md border-b-4 border-theme-color">
-        <div class="max-w-[80%] mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="max-w-[95%] mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16">
                 <div class="flex items-center">
                     <a href="<?php echo $is_vendedor ? APP_URL.'/dashboard_vendedor.php' : APP_URL.'/dashboard.php'; ?>" class="flex-shrink-0">
@@ -272,7 +280,7 @@ if ($is_vendedor && $currentPage === 'dashboard.php') {
              </div>
     </nav>
 
-    <main class="max-w-[80%] mx-auto py-6 sm:px-6 lg:px-8">
+    <main class="max-w-[95%] mx-auto py-6 sm:px-6 lg:px-8">
         <div class="px-4 py-6 sm:px-0">
             <?php if(isset($_SESSION['success_message'])): ?>
                 <div class="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 mb-4" role="alert">

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,132 @@
+body.crm-layout {
+    background-color: #f1f5f9;
+}
+
+body.crm-layout .container {
+    max-width: 100%;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.crm-shell {
+    width: 95%;
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 2rem 0 3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+}
+
+.crm-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.crm-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.crm-title {
+    font-size: clamp(1.75rem, 1.6rem + 0.5vw, 2.1rem);
+    font-weight: 700;
+    color: #1f2937;
+    margin: 0;
+}
+
+.crm-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.crm-card-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.crm-card-grid--two {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.crm-card-grid--three {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.crm-card-grid--four {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.crm-card {
+    background-color: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 30px 60px -35px rgba(15, 23, 42, 0.45);
+    padding: 1.75rem;
+}
+
+.crm-card--tight {
+    padding: 1.25rem 1.5rem;
+}
+
+.crm-card-title {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0 0 1.25rem 0;
+}
+
+.crm-card-subtitle {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #4b5563;
+    margin-bottom: 1rem;
+}
+
+.crm-card img,
+.crm-card figure img {
+    width: 100%;
+    border-radius: 12px;
+    object-fit: cover;
+}
+
+.crm-table-wrapper {
+    overflow-x: auto;
+}
+
+.crm-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.crm-table th,
+.crm-table td {
+    padding: 0.85rem 1rem;
+    text-align: left;
+}
+
+.crm-table thead th {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #475569;
+    border-bottom: 1px solid #e2e8f0;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.crm-table tbody tr {
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.crm-table tbody tr:last-child {
+    border-bottom: none;
+}
+
+.crm-table tbody tr:hover {
+    background-color: #f8fafc;
+}

--- a/crm/clientes/lista.php
+++ b/crm/clientes/lista.php
@@ -14,118 +14,122 @@ $currentUserPerfil = $_SESSION['user_perfil'] ?? '';
 $clientes = $clienteModel->getCrmProspects($currentUserId, $currentUserPerfil);
 
 $pageTitle = "CRM - Lista de Leads";
-require_once __DIR__ . '/../../app/views/layouts/header.php';
+require_once __DIR__ . '/../../app/views/layouts/crm_start.php';
 ?>
 
-<div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
-
-    <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center mb-6 gap-4">
-        <h1 class="text-3xl font-bold text-gray-800"><?php echo $pageTitle; ?></h1>
-        <div class="flex flex-col sm:flex-row gap-3">
-            <a href="<?php echo APP_URL; ?>/crm/clientes/importar.php" class="bg-green-600 text-white py-2 px-4 rounded-md shadow-md hover:bg-green-700 transition duration-300 flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
-                Importar Leads
-            </a>
-            <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php" class="bg-blue-600 text-white py-2 px-4 rounded-md shadow-md hover:bg-blue-700 transition duration-300 flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" /></svg>
-                Novo Lead
-            </a>
+    <section class="crm-section">
+        <div class="crm-section-header">
+            <h1 class="crm-title"><?php echo $pageTitle; ?></h1>
+            <div class="crm-actions">
+                <a href="<?php echo APP_URL; ?>/crm/clientes/importar.php" class="bg-emerald-600 text-white font-semibold py-2.5 px-4 rounded-xl hover:bg-emerald-700 transition inline-flex items-center">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
+                    Importar Leads
+                </a>
+                <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php" class="bg-blue-600 text-white font-semibold py-2.5 px-4 rounded-xl hover:bg-blue-700 transition inline-flex items-center">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" /></svg>
+                    Novo Lead
+                </a>
+            </div>
         </div>
-    </div>
+    </section>
 
     <?php if (isset($_SESSION['success_message'])): ?>
-        <div class="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 mb-6" role="alert">
-            <p><?php echo $_SESSION['success_message']; unset($_SESSION['success_message']); ?></p>
-        </div>
+        <section class="crm-section">
+            <div class="crm-card crm-card--tight bg-emerald-50 border border-emerald-200 text-emerald-800">
+                <?php echo $_SESSION['success_message']; unset($_SESSION['success_message']); ?>
+            </div>
+        </section>
     <?php endif; ?>
     <?php if (isset($_SESSION['error_message'])): ?>
-        <div class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-6" role="alert">
-            <p><?php echo $_SESSION['error_message']; unset($_SESSION['error_message']); ?></p>
-        </div>
+        <section class="crm-section">
+            <div class="crm-card crm-card--tight bg-red-50 border border-red-200 text-red-700">
+                <?php echo $_SESSION['error_message']; unset($_SESSION['error_message']); ?>
+            </div>
+        </section>
     <?php endif; ?>
     <?php if (isset($_SESSION['import_summary'])): ?>
         <?php $summary = $_SESSION['import_summary']; unset($_SESSION['import_summary']); ?>
-        <div class="bg-blue-50 border-l-4 border-blue-500 text-blue-700 p-4 mb-6">
-            <p class="font-semibold">Resumo da importação</p>
-            <ul class="mt-2 text-sm list-disc list-inside space-y-1">
-                <li>Leads criados: <?php echo (int)($summary['created'] ?? 0); ?></li>
-                <li>Linhas ignoradas: <?php echo (int)($summary['skipped'] ?? 0); ?></li>
-                <li>Registros duplicados: <?php echo (int)($summary['duplicates'] ?? 0); ?></li>
-            </ul>
-            <?php if (!empty($summary['errors'])): ?>
-                <div class="mt-3 text-sm">
-                    <p class="font-semibold">Ocorrências:</p>
-                    <ul class="list-disc list-inside space-y-1">
-                        <?php foreach ($summary['errors'] as $errorMessage): ?>
-                            <li><?php echo htmlspecialchars($errorMessage); ?></li>
-                        <?php endforeach; ?>
-                    </ul>
-                </div>
-            <?php endif; ?>
-        </div>
+        <section class="crm-section">
+            <div class="crm-card">
+                <h2 class="crm-card-title">Resumo da importação</h2>
+                <ul class="mt-2 text-sm list-disc list-inside space-y-1 text-gray-700">
+                    <li>Leads criados: <?php echo (int)($summary['created'] ?? 0); ?></li>
+                    <li>Linhas ignoradas: <?php echo (int)($summary['skipped'] ?? 0); ?></li>
+                    <li>Registros duplicados: <?php echo (int)($summary['duplicates'] ?? 0); ?></li>
+                </ul>
+                <?php if (!empty($summary['errors'])): ?>
+                    <div class="mt-4 text-sm text-gray-700">
+                        <p class="font-semibold">Ocorrências:</p>
+                        <ul class="list-disc list-inside space-y-1">
+                            <?php foreach ($summary['errors'] as $errorMessage): ?>
+                                <li><?php echo htmlspecialchars($errorMessage); ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </section>
     <?php endif; ?>
 
-    <div class="bg-white shadow-lg rounded-lg overflow-hidden">
-        <div class="overflow-x-auto">
-            <table class="min-w-full leading-normal">
-                <thead>
-                    <tr>
-                        <th class="px-6 py-3 border-b-2 border-gray-200 bg-gray-50 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Nome / Empresa</th>
-                        <th class="px-6 py-3 border-b-2 border-gray-200 bg-gray-50 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Lead</th>
-                        <th class="px-6 py-3 border-b-2 border-gray-200 bg-gray-50 text-center text-xs font-semibold text-gray-600 uppercase tracking-wider">Status</th>
-                        <th class="px-6 py-3 border-b-2 border-gray-200 bg-gray-50 text-center text-xs font-semibold text-gray-600 uppercase tracking-wider">Ações</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php if (empty($clientes)): ?>
+    <section class="crm-section">
+        <div class="crm-card">
+            <div class="crm-table-wrapper">
+                <table class="crm-table">
+                    <thead>
                         <tr>
-                            <td colspan="4" class="px-6 py-5 border-b border-gray-200 bg-white text-sm text-center text-gray-500">Nenhuma prospecção encontrada.</td>
+                            <th>Nome / Empresa</th>
+                            <th>Lead</th>
+                            <th class="text-center">Status</th>
+                            <th class="text-center">Ações</th>
                         </tr>
-                    <?php else: ?>
-                        <?php foreach ($clientes as $cliente): ?>
-                            <?php
-                                $totalProspeccoes = (int) ($cliente['totalProspeccoes'] ?? 0);
-                                $hasProspection = $totalProspeccoes > 0;
-                            ?>
-                            <tr class="hover:bg-gray-50">
-                                <td class="px-6 py-4 border-b border-gray-200 bg-white text-sm">
-                                    <p class="text-gray-900 whitespace-no-wrap font-medium"><?php echo htmlspecialchars($cliente['nome_cliente']); ?></p>
-                                </td>
-                                <td class="px-6 py-4 border-b border-gray-200 bg-white text-sm">
-                                    <p class="text-gray-900 whitespace-no-wrap"><?php echo htmlspecialchars($cliente['email']); ?></p>
-                                    <p class="text-gray-600 whitespace-no-wrap mt-1"><?php echo htmlspecialchars($cliente['telefone']); ?></p>
-                                </td>
-                                <td class="px-6 py-4 border-b border-gray-200 bg-white text-sm text-center">
-                                    <?php
-                                        $statusClass = $hasProspection
-                                            ? 'inline-block px-3 py-1 text-sm font-semibold text-green-800 bg-green-200 rounded-full'
-                                            : 'inline-block px-3 py-1 text-sm font-semibold text-red-800 bg-red-200 rounded-full';
-                                        $statusLabel = $hasProspection ? 'Prospecção' : 'Sem prospecção';
-                                    ?>
-                                    <span class="<?php echo $statusClass; ?>"><?php echo $statusLabel; ?></span>
-                                </td>
-                                <td class="px-6 py-4 border-b border-gray-200 bg-white text-sm text-center">
-                                    <div class="flex justify-center items-center space-x-3">
-                                        <?php if (!$hasProspection): ?>
-                                            <a href="<?php echo APP_URL; ?>/crm/prospeccoes/nova.php?cliente_id=<?php echo $cliente['id']; ?>" class="text-green-600 hover:text-green-800 font-semibold">Criar prospecção</a>
-                                        <?php endif; ?>
-                                        <a href="<?php echo APP_URL; ?>/crm/clientes/editar_cliente.php?id=<?php echo $cliente['id']; ?>" class="text-blue-600 hover:text-blue-800 font-semibold">Editar</a>
-
-                                        <form action="<?php echo APP_URL; ?>/crm/clientes/excluir_cliente.php" method="POST" onsubmit="return confirm('Tem certeza que deseja excluir este lead?');">
-                                            <input type="hidden" name="id" value="<?php echo $cliente['id']; ?>">
-                                            <button type="submit" class="text-red-600 hover:text-red-800 font-semibold">Excluir</button>
-                                        </form>
-                                    </div>
-                                </td>
+                    </thead>
+                    <tbody>
+                        <?php if (empty($clientes)): ?>
+                            <tr>
+                                <td colspan="4" class="py-6 text-center text-gray-500">Nenhuma prospecção encontrada.</td>
                             </tr>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
-                </tbody>
-            </table>
+                        <?php else: ?>
+                            <?php foreach ($clientes as $cliente): ?>
+                                <?php
+                                    $totalProspeccoes = (int) ($cliente['totalProspeccoes'] ?? 0);
+                                    $hasProspection = $totalProspeccoes > 0;
+                                ?>
+                                <tr>
+                                    <td>
+                                        <p class="font-semibold text-gray-900"><?php echo htmlspecialchars($cliente['nome_cliente']); ?></p>
+                                    </td>
+                                    <td>
+                                        <p class="text-gray-900"><?php echo htmlspecialchars($cliente['email']); ?></p>
+                                        <p class="text-gray-600 mt-1"><?php echo htmlspecialchars($cliente['telefone']); ?></p>
+                                    </td>
+                                    <td class="text-center">
+                                        <?php
+                                            $statusClass = $hasProspection
+                                                ? 'inline-flex px-3 py-1 text-xs font-semibold text-emerald-700 bg-emerald-100 rounded-full'
+                                                : 'inline-flex px-3 py-1 text-xs font-semibold text-red-700 bg-red-100 rounded-full';
+                                            $statusLabel = $hasProspection ? 'Prospecção' : 'Sem prospecção';
+                                        ?>
+                                        <span class="<?php echo $statusClass; ?>"><?php echo $statusLabel; ?></span>
+                                    </td>
+                                    <td class="text-center">
+                                        <div class="flex justify-center items-center gap-4">
+                                            <?php if (!$hasProspection): ?>
+                                                <a href="<?php echo APP_URL; ?>/crm/prospeccoes/nova.php?cliente_id=<?php echo $cliente['id']; ?>" class="text-emerald-600 hover:text-emerald-800 font-semibold">Criar prospecção</a>
+                                            <?php endif; ?>
+                                            <a href="<?php echo APP_URL; ?>/crm/clientes/editar_cliente.php?id=<?php echo $cliente['id']; ?>" class="text-blue-600 hover:text-blue-800 font-semibold">Editar</a>
+                                            <form action="<?php echo APP_URL; ?>/crm/clientes/excluir_cliente.php" method="POST" onsubmit="return confirm('Tem certeza que deseja excluir este lead?');">
+                                                <input type="hidden" name="id" value="<?php echo $cliente['id']; ?>">
+                                                <button type="submit" class="text-red-600 hover:text-red-800 font-semibold">Excluir</button>
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
-    </div>
-</div>
+    </section>
 
-<?php
-require_once __DIR__ . '/../../app/views/layouts/footer.php';
-?>
+<?php require_once __DIR__ . '/../../app/views/layouts/crm_end.php'; ?>

--- a/crm/dashboard.php
+++ b/crm/dashboard.php
@@ -87,75 +87,81 @@ try {
 
 // 2. HTML DEPOIS
 // =================================================================
-require_once __DIR__ . '/../app/views/layouts/header.php';
+require_once __DIR__ . '/../app/views/layouts/crm_start.php';
 ?>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <section class="crm-section">
+        <div class="crm-card">
+            <div class="crm-section-header">
+                <h1 class="crm-title">Dashboard de Performance</h1>
+            </div>
+            <form method="GET" action="dashboard.php" class="space-y-4">
+                <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+                    <div>
+                        <label for="start_date" class="text-sm font-medium text-gray-700">Data Início</label>
+                        <input type="date" name="start_date" id="start_date" value="<?php echo htmlspecialchars($filter_start_date); ?>" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+                    </div>
+                    <div>
+                        <label for="end_date" class="text-sm font-medium text-gray-700">Data Fim</label>
+                        <input type="date" name="end_date" id="end_date" value="<?php echo htmlspecialchars($filter_end_date); ?>" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+                    </div>
+                    <div>
+                        <label for="sdr_id" class="text-sm font-medium text-gray-700">Responsável</label>
+                        <select name="sdr_id" id="sdr_id" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+                            <option value="">Todos</option>
+                            <?php foreach ($responsaveis_filtro as $sdr): ?>
+                                <option value="<?php echo $sdr['id']; ?>" <?php echo ($sdr['id'] == $filter_sdr_id) ? 'selected' : ''; ?>>
+                                    <?php echo htmlspecialchars($sdr['nome_completo']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="flex items-end">
+                        <button type="submit" class="w-full bg-blue-600 text-white font-medium py-2 px-4 rounded-xl hover:bg-blue-700 transition">Filtrar</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </section>
 
-<div class="border-b border-gray-200 pb-5 mb-5">
-    <h1 class="text-3xl font-bold leading-tight text-gray-900">Dashboard de Performance</h1>
-    <form method="GET" action="dashboard.php" class="mt-4 p-4 bg-gray-50 rounded-lg border">
-        <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <div>
-                <label for="start_date" class="text-sm font-medium text-gray-700">Data Início</label>
-                <input type="date" name="start_date" id="start_date" value="<?php echo htmlspecialchars($filter_start_date); ?>" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+    <section class="crm-section">
+        <div class="crm-card-grid crm-card-grid--four">
+            <div class="crm-card crm-card--tight">
+                <p class="text-sm font-medium text-gray-500">Leads Criados no Período</p>
+                <p class="mt-2 text-3xl font-semibold text-gray-900"><?php echo $total_criados; ?></p>
             </div>
-            <div>
-                <label for="end_date" class="text-sm font-medium text-gray-700">Data Fim</label>
-                <input type="date" name="end_date" id="end_date" value="<?php echo htmlspecialchars($filter_end_date); ?>" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+            <div class="crm-card crm-card--tight">
+                <p class="text-sm font-medium text-gray-500">Taxa de Conversão</p>
+                <p class="mt-2 text-3xl font-semibold text-gray-900"><?php echo number_format($taxa_conversao, 1, ',', '.'); ?>%</p>
             </div>
-            <div>
-                <label for="sdr_id" class="text-sm font-medium text-gray-700">Responsável</label>
-                <select name="sdr_id" id="sdr_id" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
-                    <option value="">Todos</option>
-                    <?php foreach ($responsaveis_filtro as $sdr): ?>
-                        <option value="<?php echo $sdr['id']; ?>" <?php echo ($sdr['id'] == $filter_sdr_id) ? 'selected' : ''; ?>>
-                            <?php echo htmlspecialchars($sdr['nome_completo']); // Correção: 'nome_completo' ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
+            <div class="crm-card crm-card--tight">
+                <p class="text-sm font-medium text-gray-500">Leads Convertidos</p>
+                <p class="mt-2 text-3xl font-semibold text-green-600"><?php echo $total_convertidos; ?></p>
             </div>
-            <div class="flex items-end">
-                <button type="submit" class="bg-blue-600 text-white font-bold py-2 px-4 rounded hover:bg-blue-700 w-full">Filtrar</button>
+            <div class="crm-card crm-card--tight">
+                <p class="text-sm font-medium text-gray-500">Valor Total Ganho</p>
+                <p class="mt-2 text-3xl font-semibold text-green-600">R$ <?php echo number_format($valor_total_ganho ?? 0, 2, ',', '.'); ?></p>
             </div>
         </div>
-    </form>
-</div>
+    </section>
 
-<div class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
-    <div class="bg-white overflow-hidden shadow rounded-lg p-5">
-        <dt class="text-sm font-medium text-gray-500 truncate">Leads Criados no Período</dt>
-        <dd class="mt-1 text-3xl font-semibold text-gray-900"><?php echo $total_criados; ?></dd>
-    </div>
-    <div class="bg-white overflow-hidden shadow rounded-lg p-5">
-        <dt class="text-sm font-medium text-gray-500 truncate">Taxa de Conversão</dt>
-        <dd class="mt-1 text-3xl font-semibold text-gray-900"><?php echo number_format($taxa_conversao, 1, ',', '.'); ?>%</dd>
-    </div>
-    <div class="bg-white overflow-hidden shadow rounded-lg p-5">
-        <dt class="text-sm font-medium text-gray-500 truncate">Leads Convertidos</dt>
-        <dd class="mt-1 text-3xl font-semibold text-green-600"><?php echo $total_convertidos; ?></dd>
-    </div>
-    <div class="bg-white overflow-hidden shadow rounded-lg p-5">
-        <dt class="text-sm font-medium text-gray-500 truncate">Valor Total Ganho</dt>
-        <dd class="mt-1 text-3xl font-semibold text-green-600">R$ <?php echo number_format($valor_total_ganho ?? 0, 2, ',', '.'); ?></dd>
-    </div>
-</div>
-
-<div class="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
-    <div class="bg-white overflow-hidden shadow rounded-lg p-6">
-        <h3 class="text-lg font-medium leading-6 text-gray-900">Prospecções por Status</h3>
-        <div class="mt-4" style="height: 300px;"><canvas id="graficoStatus"></canvas></div>
-    </div>
-    <div class="bg-white overflow-hidden shadow rounded-lg p-6">
-        <h3 class="text-lg font-medium leading-6 text-gray-900">Prospecções por Responsável</h3>
-        <div class="mt-4" style="height: 300px;"><canvas id="graficoResponsavel"></canvas></div>
-    </div>
-    <div class="bg-white overflow-hidden shadow rounded-lg p-6 lg:col-span-2">
-        <h3 class="text-lg font-medium leading-6 text-gray-900">Leads por Canal de Origem</h3>
-        <div class="mt-4" style="height: 300px;"><canvas id="graficoCanais"></canvas></div>
-    </div>
-</div>
-
+    <section class="crm-section">
+        <div class="grid grid-cols-1 gap-8 lg:grid-cols-2">
+            <div class="crm-card">
+                <h2 class="crm-card-title">Prospecções por Status</h2>
+                <div style="height: 300px;"><canvas id="graficoStatus"></canvas></div>
+            </div>
+            <div class="crm-card">
+                <h2 class="crm-card-title">Prospecções por Responsável</h2>
+                <div style="height: 300px;"><canvas id="graficoResponsavel"></canvas></div>
+            </div>
+            <div class="crm-card lg:col-span-2">
+                <h2 class="crm-card-title">Leads por Canal de Origem</h2>
+                <div style="height: 300px;"><canvas id="graficoCanais"></canvas></div>
+            </div>
+        </div>
+    </section>
 <script>
 document.addEventListener('DOMContentLoaded', (event) => {
     const chartColors = ['rgba(59, 130, 246, 0.7)', 'rgba(16, 185, 129, 0.7)', 'rgba(239, 68, 68, 0.7)', 'rgba(245, 158, 11, 0.7)', 'rgba(107, 114, 128, 0.7)', 'rgba(139, 92, 246, 0.7)', 'rgba(236, 72, 153, 0.7)', 'rgba(34, 211, 238, 0.7)'];
@@ -174,7 +180,4 @@ document.addEventListener('DOMContentLoaded', (event) => {
 });
 </script>
 
-<?php 
-// 3. Inclui o footer no final
-require_once __DIR__ . '/../app/views/layouts/footer.php'; 
-?>
+<?php require_once __DIR__ . '/../app/views/layouts/crm_end.php'; ?>

--- a/crm/prospeccoes/kanban.php
+++ b/crm/prospeccoes/kanban.php
@@ -3,7 +3,6 @@ require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
 require_once __DIR__ . '/../../app/models/Prospeccao.php';
 require_once __DIR__ . '/../../app/services/KanbanConfigService.php';
-require_once __DIR__ . '/../../app/views/layouts/header.php';
 
 $kanbanConfigService = new KanbanConfigService($pdo);
 $prospectionModel = new Prospeccao($pdo);
@@ -103,6 +102,8 @@ if ($isVendor) {
 $assignableLeadsCount = count($assignableLeads ?? []);
 $defaultKanbanDestination = $kanbanColumns[0] ?? '';
 ?>
+
+<?php require_once __DIR__ . '/../../app/views/layouts/crm_start.php'; ?>
 
 <style>
     .kanban-board {
@@ -213,21 +214,23 @@ $defaultKanbanDestination = $kanbanColumns[0] ?? '';
     }
 </style>
 
-<div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between border-b border-gray-200 pb-4 mb-4">
-    <div class="flex items-center justify-between gap-3">
-        <h1 class="text-2xl font-bold text-gray-800">Funil de Vendas (Kanban)</h1>
-        <a href="<?php echo APP_URL; ?>/crm/prospeccoes/lista.php" class="bg-gray-200 text-gray-700 font-bold py-2 px-4 rounded-lg hover:bg-gray-300">Ver em Lista</a>
+<section class="crm-section">
+    <div class="crm-section-header">
+        <h1 class="crm-title">Funil de Vendas (Kanban)</h1>
+        <div class="crm-actions">
+            <a href="<?php echo APP_URL; ?>/crm/prospeccoes/lista.php" class="bg-slate-600 text-white font-semibold py-2.5 px-4 rounded-xl hover:bg-slate-700 transition">Ver em Lista</a>
+        </div>
     </div>
-    <div class="flex flex-wrap items-center gap-3">
+    <div class="crm-card space-y-4">
         <?php if ($isVendor): ?>
-            <div class="text-sm text-gray-600 bg-blue-50 border border-blue-200 rounded-lg px-3 py-2">
-                <span class="font-semibold text-blue-700">Filtro ativo:</span>
+            <div class="text-sm text-blue-700 bg-blue-50 border border-blue-200 rounded-xl px-4 py-3">
+                <span class="font-semibold">Filtro ativo:</span>
                 <span><?php echo htmlspecialchars($_SESSION['user_nome'] ?? 'Seus leads'); ?></span>
             </div>
         <?php else: ?>
-            <form method="get" class="flex items-center gap-2" id="sellerFilterForm">
-                <label for="sellerFilter" class="text-sm text-gray-700 font-medium">Vendedor</label>
-                <select name="responsavel_id" id="sellerFilter" class="border border-gray-300 rounded-lg py-2 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <form method="get" class="flex flex-wrap items-center gap-3" id="sellerFilterForm">
+                <label for="sellerFilter" class="text-sm font-medium text-gray-700">Vendedor</label>
+                <select name="responsavel_id" id="sellerFilter" class="border border-gray-300 rounded-xl py-2 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
                     <option value="" <?php echo $defaultFilterValue === 'all' ? 'selected' : ''; ?>>Todos os vendedores</option>
                     <?php foreach ($kanbanOwners as $owner): ?>
                         <option value="<?php echo (int)$owner['id']; ?>" <?php echo ((string)$owner['id'] === $defaultFilterValue) ? 'selected' : ''; ?>>
@@ -245,30 +248,36 @@ $defaultKanbanDestination = $kanbanColumns[0] ?? '';
                 });
             </script>
         <?php endif; ?>
-        <button id="openAddLeadsModal" class="bg-indigo-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" <?php echo $assignableLeadsCount === 0 ? 'disabled' : ''; ?>>Adicionar leads ao Kanban<?php echo $assignableLeadsCount > 0 ? ' (' . $assignableLeadsCount . ')' : ''; ?></button>
-        <?php if ($assignableLeadsCount === 0): ?>
-            <span class="text-xs text-gray-500">Nenhum lead disponível fora do Kanban para este filtro.</span>
-        <?php endif; ?>
-        <button id="toggleSelectionBtn" class="bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors">Selecionar múltiplos</button>
-        <div id="bulkActions" class="hidden items-center gap-2">
-            <span class="text-sm text-gray-600">Selecionados: <span id="selectedCount">0</span></span>
-            <select id="bulkStatusSelect" class="border border-gray-300 rounded-lg py-2 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
-                <?php foreach ($kanbanColumns as $column): ?>
-                    <option value="<?php echo htmlspecialchars($column); ?>"><?php echo htmlspecialchars($column); ?></option>
-                <?php endforeach; ?>
-            </select>
-            <button id="bulkMoveBtn" class="bg-green-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled>Mover selecionados</button>
+        <div class="flex flex-wrap items-center gap-3">
+            <button id="openAddLeadsModal" class="bg-indigo-600 text-white font-semibold py-2.5 px-4 rounded-xl hover:bg-indigo-700 transition disabled:opacity-50 disabled:cursor-not-allowed" <?php echo $assignableLeadsCount === 0 ? 'disabled' : ''; ?>>Adicionar leads ao Kanban<?php echo $assignableLeadsCount > 0 ? ' (' . $assignableLeadsCount . ')' : ''; ?></button>
+            <?php if ($assignableLeadsCount === 0): ?>
+                <span class="text-xs text-gray-500">Nenhum lead disponível fora do Kanban para este filtro.</span>
+            <?php endif; ?>
+            <button id="toggleSelectionBtn" class="bg-blue-600 text-white font-semibold py-2.5 px-4 rounded-xl hover:bg-blue-700 transition">Selecionar múltiplos</button>
+            <div id="bulkActions" class="hidden items-center gap-2">
+                <span class="text-sm text-gray-600">Selecionados: <span id="selectedCount">0</span></span>
+                <select id="bulkStatusSelect" class="border border-gray-300 rounded-xl py-2 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    <?php foreach ($kanbanColumns as $column): ?>
+                        <option value="<?php echo htmlspecialchars($column); ?>"><?php echo htmlspecialchars($column); ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <button id="bulkMoveBtn" class="bg-green-600 text-white font-semibold py-2.5 px-4 rounded-xl hover:bg-green-700 transition disabled:opacity-50 disabled:cursor-not-allowed" disabled>Mover selecionados</button>
+            </div>
         </div>
     </div>
-</div>
+</section>
 
 <?php if ($errorMessage): ?>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4 text-sm">
-        <?php echo htmlspecialchars($errorMessage); ?>
-    </div>
+    <section class="crm-section">
+        <div class="crm-card crm-card--tight bg-red-50 border border-red-200 text-red-700">
+            <?php echo htmlspecialchars($errorMessage); ?>
+        </div>
+    </section>
 <?php endif; ?>
 
-<div class="kanban-board" id="kanbanBoard">
+<section class="crm-section">
+    <div class="crm-card overflow-hidden">
+        <div class="kanban-board" id="kanbanBoard">
     <?php foreach ($kanbanColumns as $column): ?>
         <div class="kanban-column">
             <h3>
@@ -307,7 +316,9 @@ $defaultKanbanDestination = $kanbanColumns[0] ?? '';
             </div>
         </div>
     <?php endforeach; ?>
-</div>
+        </div>
+    </div>
+</section>
 
 <div id="addLeadsModal" class="hidden fixed inset-0 z-40">
     <div class="flex items-center justify-center min-h-screen">
@@ -725,6 +736,4 @@ $defaultKanbanDestination = $kanbanColumns[0] ?? '';
     });
 </script>
 
-<?php
-require_once __DIR__ . '/../../app/views/layouts/footer.php';
-?>
+<?php require_once __DIR__ . '/../../app/views/layouts/crm_end.php'; ?>

--- a/crm/prospeccoes/lista.php
+++ b/crm/prospeccoes/lista.php
@@ -3,6 +3,7 @@ require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
 
 $pageTitle = "Lista de Prospecções";
+$bodyClass = 'crm-layout';
 
 // --- INÍCIO DA LÓGICA DE FILTRO E CONTROLE DE ACESSO ---
 $where_clauses = [];
@@ -90,158 +91,112 @@ $status_list = ['prospecção', 'qualificação', 'apresentação', 'negociaçã
 
 // --- FIM DA LÓGICA DE CONSULTA ---
 
-require_once __DIR__ . '/../../app/views/layouts/header.php';
+require_once __DIR__ . '/../../app/views/layouts/crm_start.php';
 ?>
-
-<div class="container mx-auto px-4 py-8">
-    <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-bold text-gray-800">Lista de Prospecções</h1>
-        <div>
-            <a href="nova.php" class="bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700 shadow-sm">
-                + Nova Prospecção
-            </a>
-            <a href="kanban.php" class="bg-gray-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-gray-600 shadow-sm ml-2">
-                Ver Kanban
-            </a>
+    <section class="crm-section">
+        <div class="crm-section-header">
+            <h1 class="crm-title">Lista de Prospecções</h1>
+            <div class="crm-actions">
+                <a href="nova.php" class="bg-blue-600 text-white font-semibold py-2.5 px-4 rounded-xl hover:bg-blue-700 transition">+ Nova Prospecção</a>
+                <a href="kanban.php" class="bg-slate-600 text-white font-semibold py-2.5 px-4 rounded-xl hover:bg-slate-700 transition">Ver Kanban</a>
+            </div>
         </div>
-    </div>
-
-    <div class="bg-white p-6 rounded-lg shadow-md mb-6">
-    <h2 class="text-lg font-semibold text-gray-700 mb-4">Filtros</h2>
-    <form action="" method="GET" class="space-y-6">
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-            <!-- Campo de busca -->
-            <div>
-                <label for="search" class="block text-sm font-medium text-gray-600 mb-2">Buscar</label>
-                <input type="text" name="search" id="search" class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" value="<?php echo htmlspecialchars($search_term); ?>" placeholder="Nome do prospecto ou lead...">
-            </div>
-
-            <!-- Campo de status -->
-            <div>
-                <label for="status" class="block text-sm font-medium text-gray-600 mb-2">Status</label>
-                <select name="status" id="status" class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                    <option value="">Todos</option>
-                    <?php foreach ($status_list as $status_item): ?>
-                        <option value="<?php echo $status_item; ?>" <?php echo ($search_status === $status_item) ? 'selected' : ''; ?>>
-                            <?php echo ucfirst($status_item); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-
-            <!-- Campo de responsável (visível apenas se o perfil não for 'vendedor') -->
-            <?php if ($user_perfil !== 'vendedor'): ?>
-            <div>
-                <label for="responsavel_id" class="block text-sm font-medium text-gray-600 mb-2">Responsável</label>
-                <select name="responsavel_id" id="responsavel_id" class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                    <option value="">Todos</option>
-                    <?php foreach ($responsaveis as $responsavel): ?>
-                        <option value="<?php echo $responsavel['id']; ?>" <?php echo ($search_responsavel == $responsavel['id']) ? 'selected' : ''; ?>>
-                            <?php echo htmlspecialchars($responsavel['nome_completo']); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            <?php endif; ?>
-
-            <!-- Campos de data -->
-            <div class="grid grid-cols-2 gap-4">
-                <div>
-                    <label for="data_inicio" class="block text-sm font-medium text-gray-600 mb-2">De</label>
-                    <input type="date" name="data_inicio" id="data_inicio" class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" value="<?php echo htmlspecialchars($search_data_inicio); ?>">
+        <div class="crm-card">
+            <h2 class="crm-card-title">Filtros</h2>
+            <form action="" method="GET" class="space-y-6">
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                    <div>
+                        <label for="search" class="block text-sm font-medium text-gray-600 mb-2">Buscar</label>
+                        <input type="text" name="search" id="search" class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" value="<?php echo htmlspecialchars($search_term); ?>" placeholder="Nome do prospecto ou lead...">
+                    </div>
+                    <div>
+                        <label for="status" class="block text-sm font-medium text-gray-600 mb-2">Status</label>
+                        <select name="status" id="status" class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                            <option value="">Todos</option>
+                            <?php foreach ($status_list as $status_item): ?>
+                                <option value="<?php echo $status_item; ?>" <?php echo ($search_status === $status_item) ? 'selected' : ''; ?>>
+                                    <?php echo ucfirst($status_item); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <?php if ($user_perfil !== 'vendedor'): ?>
+                    <div>
+                        <label for="responsavel_id" class="block text-sm font-medium text-gray-600 mb-2">Responsável</label>
+                        <select name="responsavel_id" id="responsavel_id" class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                            <option value="">Todos</option>
+                            <?php foreach ($responsaveis as $responsavel): ?>
+                                <option value="<?php echo $responsavel['id']; ?>" <?php echo ($search_responsavel == $responsavel['id']) ? 'selected' : ''; ?>>
+                                    <?php echo htmlspecialchars($responsavel['nome_completo']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <?php endif; ?>
+                    <div class="grid grid-cols-2 gap-4">
+                        <div>
+                            <label for="data_inicio" class="block text-sm font-medium text-gray-600 mb-2">De</label>
+                            <input type="date" name="data_inicio" id="data_inicio" class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" value="<?php echo htmlspecialchars($search_data_inicio); ?>">
+                        </div>
+                        <div>
+                            <label for="data_fim" class="block text-sm font-medium text-gray-600 mb-2">Até</label>
+                            <input type="date" name="data_fim" id="data_fim" class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" value="<?php echo htmlspecialchars($search_data_fim); ?>">
+                        </div>
+                    </div>
                 </div>
-                <div>
-                    <label for="data_fim" class="block text-sm font-medium text-gray-600 mb-2">Até</label>
-                    <input type="date" name="data_fim" id="data_fim" class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" value="<?php echo htmlspecialchars($search_data_fim); ?>">
+                <div class="flex flex-col sm:flex-row justify-end gap-3">
+                    <a href="lista.php" class="inline-flex justify-center items-center bg-slate-200 text-slate-800 font-medium px-6 py-2 rounded-xl hover:bg-slate-300 transition">Limpar</a>
+                    <button type="submit" class="inline-flex justify-center items-center bg-blue-600 text-white font-medium px-6 py-2 rounded-xl hover:bg-blue-700 transition">Filtrar</button>
                 </div>
-            </div>
+            </form>
         </div>
-
-        <!-- Botões -->
-        <div class="flex justify-between items-center space-x-2">
-            <a href="lista.php" class="bg-gray-300 text-gray-700 font-bold py-2 px-4 rounded-lg hover:bg-gray-400 transition duration-200">Limpar</a>
-            <button type="submit" class="bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700 transition duration-200">Filtrar</button>
-        </div>
-    </form>
-</div>
-
-
-
-    <div class="bg-white overflow-x-auto shadow-md rounded-lg">
-        <table class="min-w-full divide-y divide-gray-200">
-            <thead class="bg-gray-50">
-                <tr>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Prospecto</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Lead</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Valor</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Responsável</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Data</th>
-                    <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase">Ações</th>
-                </tr>
-            </thead>
-            <tbody class="bg-white divide-y divide-gray-200">
-                <?php if (empty($prospeccoes)): ?>
-                    <tr>
-                        <td colspan="7" class="px-6 py-4 text-center text-gray-500">Nenhuma prospecção encontrada com os filtros aplicados.</td>
-                    </tr>
-                <?php else: ?>
-                    <?php foreach ($prospeccoes as $prospeccao): ?>
+    </section>
+    <section class="crm-section">
+        <div class="crm-card crm-card--tight">
+            <h2 class="crm-card-title">Resultado</h2>
+            <div class="crm-table-wrapper">
+                <table class="crm-table">
+                    <thead>
                         <tr>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"><?php echo htmlspecialchars($prospeccao['nome_prospecto']); ?></td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600"><?php echo htmlspecialchars($prospeccao['nome_cliente'] ?? 'Lead não vinculado'); ?></td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                                <span class="
-                                    <?php 
-                                        $status = strtolower($prospeccao['status']); // Converte para minúsculo para garantir que a comparação seja feita de forma insensível ao caso
-
-                                        switch ($status) {
-                                            case 'cliente ativo':
-                                                echo 'px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800';
-                                                break;
-                                            case 'primeiro contato':
-                                                echo 'px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800';
-                                                break;
-                                            case 'segundo contato':
-                                                echo 'px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800';
-                                                break;
-                                            case 'terceiro contato':
-                                                echo 'px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-indigo-100 text-indigo-800';
-                                                break;
-                                            case 'reunião agendada':
-                                                echo 'px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800';
-                                                break;
-                                            case 'proposta enviada':
-                                                echo 'px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-teal-100 text-teal-800';
-                                                break;
-                                            case 'fechamento':
-                                                echo 'px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800';
-                                                break;
-                                            case 'pausar':
-                                                echo 'px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800';
-                                                break;
-                                            default:
-                                                echo 'px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800';
-                                                break;
-                                        }
-                                    ?>
-                                ">
-                                    <?php echo htmlspecialchars(ucfirst($prospeccao['status'])); ?>
-                                </span>
-                            </td>
-
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-600">R$ <?php echo number_format($prospeccao['valor_proposto'] ?? 0, 2, ',', '.'); ?></td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600"><?php echo htmlspecialchars($prospeccao['nome_responsavel'] ?? 'N/A'); ?></td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600"><?php echo date('d/m/Y', strtotime($prospeccao['data_prospeccao'])); ?></td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-center">
-                                <a href="detalhes.php?id=<?php echo $prospeccao['id']; ?>" class="text-indigo-600 hover:text-indigo-900">Detalhes</a>
-                            </td>
+                            <th>Prospecto</th>
+                            <th>Lead</th>
+                            <th>Status</th>
+                            <th class="text-right">Valor</th>
+                            <th>Responsável</th>
+                            <th>Data</th>
+                            <th class="text-center">Ações</th>
                         </tr>
-                    <?php endforeach; ?>
-                <?php endif; ?>
-            </tbody>
-        </table>
-    </div>
-</div>
-
-<?php require_once __DIR__ . '/../../app/views/layouts/footer.php'; ?>
+                    </thead>
+                    <tbody>
+                        <?php if (empty($prospeccoes)): ?>
+                            <tr>
+                                <td colspan="7" class="py-6 text-center text-gray-500">Nenhuma prospecção encontrada com os filtros aplicados.</td>
+                            </tr>
+                        <?php else: ?>
+                            <?php foreach ($prospeccoes as $prospeccao): ?>
+                                <tr>
+                                    <td>
+                                        <div class="font-semibold text-gray-900"><?php echo htmlspecialchars($prospeccao['nome_prospecto']); ?></div>
+                                        <div class="text-sm text-gray-500">Origem: <?php echo htmlspecialchars($prospeccao['origem'] ?? 'Não informado'); ?></div>
+                                    </td>
+                                    <td><?php echo htmlspecialchars($prospeccao['nome_cliente'] ?? 'Lead não vinculado'); ?></td>
+                                    <td>
+                                        <span class="inline-flex px-3 py-1 rounded-full text-xs font-semibold bg-blue-100 text-blue-600">
+                                            <?php echo htmlspecialchars(ucfirst($prospeccao['status'])); ?>
+                                        </span>
+                                    </td>
+                                    <td class="text-right">R$ <?php echo number_format($prospeccao['valor_proposto'] ?? 0, 2, ',', '.'); ?></td>
+                                    <td><?php echo htmlspecialchars($prospeccao['nome_responsavel'] ?? 'N/A'); ?></td>
+                                    <td><?php echo date('d/m/Y', strtotime($prospeccao['data_prospeccao'])); ?></td>
+                                    <td class="text-center">
+                                        <a href="detalhes.php?id=<?php echo $prospeccao['id']; ?>" class="text-blue-600 hover:text-blue-800 font-semibold">Detalhes</a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+<?php require_once __DIR__ . '/../../app/views/layouts/crm_end.php'; ?>

--- a/crm/prospeccoes/nova.php
+++ b/crm/prospeccoes/nova.php
@@ -37,7 +37,7 @@ if (!empty($cliente_pre_selecionado_id)) {
     }
 }
 
-require_once __DIR__ . '/../../app/views/layouts/header.php';
+require_once __DIR__ . '/../../app/views/layouts/crm_start.php';
 ?>
 
 <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
@@ -48,53 +48,55 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
     .select2-container--default .select2-selection--single .select2-selection__arrow { height: 2.5rem; }
 </style>
 
-<div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-    <h1 class="text-2xl font-bold text-gray-800 mb-6">Criar Nova Prospecção</h1>
+<section class="crm-section">
+    <div class="crm-card">
+        <h1 class="crm-card-title">Criar Nova Prospecção</h1>
 
-    <?php if (isset($_SESSION['success_message'])): ?>
-        <div class="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 mb-6" role="alert">
-            <p><?php echo $_SESSION['success_message']; unset($_SESSION['success_message']); ?></p>
-        </div>
-    <?php endif; ?>
+        <?php if (isset($_SESSION['success_message'])): ?>
+            <div class="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-emerald-800">
+                <?php echo $_SESSION['success_message']; unset($_SESSION['success_message']); ?>
+            </div>
+        <?php endif; ?>
 
-    <?php if (isset($_SESSION['error_message'])): ?>
-        <div class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-6" role="alert">
-            <p><?php echo $_SESSION['error_message']; unset($_SESSION['error_message']); ?></p>
-        </div>
-    <?php endif; ?>
+        <?php if (isset($_SESSION['error_message'])): ?>
+            <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+                <?php echo $_SESSION['error_message']; unset($_SESSION['error_message']); ?>
+            </div>
+        <?php endif; ?>
 
-    <?php if (empty($clientes)): ?>
-        <div class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-6" role="alert">
-            <p class="font-bold">Nenhum lead encontrado!</p>
-            <p>Você precisa cadastrar um lead antes. <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php" class="font-bold underline hover:text-yellow-800">Clique aqui para cadastrar.</a></p>
-        </div>
-    <?php else: ?>
-        <form action="<?php echo APP_URL; ?>/crm/prospeccoes/salvar.php" method="POST" id="form-nova-prospeccao" class="space-y-6">
-            <div>
-                <label for="cliente_id" class="block text-sm font-medium text-gray-700">Nome do Lead</label>
-                <div class="flex items-center space-x-2 mt-1">
-                    <select name="cliente_id" id="cliente_id" class="block w-full">
-                        <option></option>
-                        <?php foreach ($clientes as $cliente): ?>
-                            <option value="<?php echo $cliente['id']; ?>" <?php echo ($cliente['id'] == $cliente_pre_selecionado_id) ? 'selected' : ''; ?>>
-                                <?php echo htmlspecialchars($cliente['nome_cliente']); ?>
-                            </option>
-                        <?php endforeach; ?>
-                    </select>
-                    <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php?redirect_url=<?php echo urlencode(APP_URL . '/crm/prospeccoes/nova.php'); ?>"
-                       class="flex-shrink-0 bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-md text-sm">
-                        Novo Lead
-                    </a>
+        <?php if (empty($clientes)): ?>
+            <div class="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-amber-700">
+                <p class="font-semibold">Nenhum lead encontrado!</p>
+                <p>Você precisa cadastrar um lead antes. <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php" class="font-semibold underline hover:text-amber-800">Clique aqui para cadastrar.</a></p>
+            </div>
+        <?php else: ?>
+            <form action="<?php echo APP_URL; ?>/crm/prospeccoes/salvar.php" method="POST" id="form-nova-prospeccao" class="space-y-6 mt-6">
+                <div>
+                    <label for="cliente_id" class="block text-sm font-medium text-gray-700">Nome do Lead</label>
+                    <div class="flex flex-col sm:flex-row sm:items-center sm:space-x-3 mt-2 gap-3">
+                        <select name="cliente_id" id="cliente_id" class="block w-full">
+                            <option></option>
+                            <?php foreach ($clientes as $cliente): ?>
+                                <option value="<?php echo $cliente['id']; ?>" <?php echo ($cliente['id'] == $cliente_pre_selecionado_id) ? 'selected' : ''; ?>>
+                                    <?php echo htmlspecialchars($cliente['nome_cliente']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                        <a href="<?php echo APP_URL; ?>/crm/clientes/novo.php?redirect_url=<?php echo urlencode(APP_URL . '/crm/prospeccoes/nova.php'); ?>"
+                           class="inline-flex items-center justify-center bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-2.5 px-4 rounded-xl text-sm">
+                            Novo Lead
+                        </a>
+                    </div>
                 </div>
-            </div>
 
-            <div class="flex justify-end pt-4">
-                <a href="<?php echo APP_URL; ?>/crm/prospeccoes/lista.php" class="bg-gray-200 text-gray-700 font-bold py-2 px-4 rounded hover:bg-gray-300 mr-3">Cancelar</a>
-                <button type="submit" class="bg-blue-600 text-white font-bold py-2 px-4 rounded hover:bg-blue-700">Salvar Prospecção</button>
-            </div>
-        </form>
-    <?php endif; ?>
-</div>
+                <div class="flex flex-col sm:flex-row justify-end gap-3 pt-4">
+                    <a href="<?php echo APP_URL; ?>/crm/prospeccoes/lista.php" class="inline-flex justify-center items-center bg-slate-200 text-slate-800 font-medium py-2.5 px-4 rounded-xl hover:bg-slate-300 transition">Cancelar</a>
+                    <button type="submit" class="inline-flex justify-center items-center bg-blue-600 text-white font-medium py-2.5 px-4 rounded-xl hover:bg-blue-700 transition">Salvar Prospecção</button>
+                </div>
+            </form>
+        <?php endif; ?>
+    </div>
+</section>
 
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
@@ -124,6 +126,4 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
     });
 </script>
 
-<?php 
-require_once __DIR__ . '/../../app/views/layouts/footer.php'; 
-?>
+<?php require_once __DIR__ . '/../../app/views/layouts/crm_end.php'; ?>


### PR DESCRIPTION
## Summary
- adiciona parciais dedicadas para iniciar e finalizar páginas do CRM com largura padronizada
- atualiza páginas principais do CRM (dashboard, listas, kanban e novo prospect) para usar a nova estrutura unificada
- ajusta estilos globais para harmonizar cartões, títulos e alertas das telas do CRM

## Testing
- php -l app/views/layouts/header.php
- php -l crm/prospeccoes/lista.php
- php -l crm/dashboard.php
- php -l crm/prospeccoes/kanban.php
- php -l crm/clientes/lista.php
- php -l crm/prospeccoes/nova.php
- php -l app/views/layouts/crm_start.php
- php -l app/views/layouts/crm_end.php

------
https://chatgpt.com/codex/tasks/task_e_68e1ab82ee0c8330a44a88f75ce03793