### PR TITLE
Move lead category management into prospections

### DIFF
--- a/app/models/Prospeccao.php
+++ b/app/models/Prospeccao.php
@@ -189,6 +189,7 @@ class Prospeccao
                     p.nome_prospecto,
                     p.valor_proposto,
                     p.status,
+                    p.leadCategory,
                     p.responsavel_id,
                     p.data_ultima_atualizacao,
                     c.nome_cliente,
@@ -273,6 +274,7 @@ class Prospeccao
         $sql = "SELECT
                     p.id,
                     p.nome_prospecto,
+                    p.leadCategory,
                     p.responsavel_id,
                     p.status,
                     p.data_ultima_atualizacao,

--- a/app/utils/LeadCategory.php
+++ b/app/utils/LeadCategory.php
@@ -1,0 +1,32 @@
+<?php
+
+class LeadCategory
+{
+    public const DEFAULT = 'Entrada';
+
+    private const CATEGORIES = [
+        self::DEFAULT,
+        'Qualificado',
+        'Com Orçamento',
+        'Em Negociação',
+        'Cliente Ativo',
+        'Sem Interesse',
+    ];
+
+    /**
+     * @return array<int, string>
+     */
+    public static function all(): array
+    {
+        return self::CATEGORIES;
+    }
+
+    public static function isValid(?string $category): bool
+    {
+        if ($category === null) {
+            return false;
+        }
+
+        return in_array($category, self::CATEGORIES, true);
+    }
+}

--- a/crm/clientes/editar_cliente.php
+++ b/crm/clientes/editar_cliente.php
@@ -89,16 +89,8 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                     <option value="Outro" <?php echo ($cliente['canal_origem'] == 'Outro') ? 'selected' : ''; ?>>Outro</option>
                 </select>
             </div>
-            <div>
-                <label for="categoria" class="block text-sm font-medium text-gray-700">Categoria</label>
-                <select name="categoria" id="categoria" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
-                    <option value="Entrada" <?php echo ($cliente['categoria'] == 'Entrada') ? 'selected' : ''; ?>>Entrada</option>
-                    <option value="Qualificado" <?php echo ($cliente['categoria'] == 'Qualificado') ? 'selected' : ''; ?>>Qualificado</option>
-                    <option value="Com Orçamento" <?php echo ($cliente['categoria'] == 'Com Orçamento') ? 'selected' : ''; ?>>Com Orçamento</option>
-                    <option value="Em Negociação" <?php echo ($cliente['categoria'] == 'Em Negociação') ? 'selected' : ''; ?>>Em Negociação</option>
-                    <option value="Cliente Ativo" <?php echo ($cliente['categoria'] == 'Cliente Ativo') ? 'selected' : ''; ?>>Lead Ativo</option>
-                    <option value="Sem Interesse" <?php echo ($cliente['categoria'] == 'Sem Interesse') ? 'selected' : ''; ?>>Sem Interesse</option>
-                </select>
+            <div class="md:col-span-2">
+                <p class="text-xs text-gray-500 bg-gray-50 border border-gray-200 rounded-md px-3 py-2">A categoria do lead agora é controlada pelas prospecções vinculadas. Atualize o estágio diretamente na prospecção.</p>
             </div>
         </div>
 

--- a/crm/clientes/importar.php
+++ b/crm/clientes/importar.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
 require_once __DIR__ . '/../../app/models/User.php';
+require_once __DIR__ . '/../../app/utils/LeadCategory.php';
 
 $userModel = new User($pdo);
 
@@ -21,17 +22,7 @@ $channelOptions = [
     'Outro'
 ];
 
-$categoryOptions = [
-    'Entrada',
-    'Qualificado',
-    'Com Orçamento',
-    'Em Negociação',
-    'Cliente Ativo',
-    'Sem Interesse'
-];
-
 $defaultChannel = 'Outro';
-$defaultCategory = 'Entrada';
 
 $assignedOwnerId = $currentUserPerfil === 'vendedor' ? $currentUserId : null;
 $vendors = $currentUserPerfil === 'vendedor' ? [] : $userModel->getActiveVendors();
@@ -61,15 +52,6 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                 </div>
 
                 <div>
-                    <label for="default_category" class="block text-sm font-medium text-gray-700">Categoria padrão</label>
-                    <select id="default_category" name="default_category" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
-                        <?php foreach ($categoryOptions as $category): ?>
-                            <option value="<?php echo htmlspecialchars($category); ?>" <?php echo $category === $defaultCategory ? 'selected' : ''; ?>><?php echo htmlspecialchars($category); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </div>
-
-                <div>
                     <label for="delimiter" class="block text-sm font-medium text-gray-700">Delimitador</label>
                     <select id="delimiter" name="delimiter" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
                         <option value=";">Ponto e vírgula (;)</option>
@@ -82,6 +64,8 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                     <label for="has_header" class="ml-2 block text-sm text-gray-700">Primeira linha contém cabeçalho</label>
                 </div>
             </div>
+
+            <p class="text-xs text-gray-500 bg-gray-50 border border-gray-200 rounded-md px-3 py-2">Todos os leads importados serão criados com a categoria padrão "<?php echo htmlspecialchars(LeadCategory::DEFAULT); ?>" e poderão ser atualizados nas prospecções.</p>
 
             <?php if ($currentUserPerfil === 'vendedor'): ?>
                 <input type="hidden" name="assigned_owner" value="<?php echo (int) $assignedOwnerId; ?>" />

--- a/crm/clientes/importar_processar.php
+++ b/crm/clientes/importar_processar.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
+require_once __DIR__ . '/../../app/utils/LeadCategory.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     header('Location: ' . APP_URL . '/crm/clientes/lista.php');
@@ -35,24 +36,12 @@ $channelOptions = [
     'Outro'
 ];
 
-$categoryOptions = [
-    'Entrada',
-    'Qualificado',
-    'Com Orçamento',
-    'Em Negociação',
-    'Cliente Ativo',
-    'Sem Interesse'
-];
-
 $defaultChannel = $_POST['default_channel'] ?? 'Outro';
 if (!in_array($defaultChannel, $channelOptions, true)) {
     $defaultChannel = 'Outro';
 }
 
-$defaultCategory = $_POST['default_category'] ?? 'Entrada';
-if (!in_array($defaultCategory, $categoryOptions, true)) {
-    $defaultCategory = 'Entrada';
-}
+$defaultCategory = LeadCategory::DEFAULT;
 
 $delimiter = $_POST['delimiter'] ?? ';';
 $allowedDelimiters = [';', ',', '\t'];

--- a/crm/clientes/integracao_bitrix.php
+++ b/crm/clientes/integracao_bitrix.php
@@ -5,6 +5,7 @@
 // =================================================================
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
+require_once __DIR__ . '/../../app/utils/LeadCategory.php';
 
 // 2. Verificação de permissão CORRIGIDA
 if (!isset($_SESSION['user_perfil']) || !in_array($_SESSION['user_perfil'], ['admin', 'gerencia', 'supervisor'])) {
@@ -106,7 +107,7 @@ if ($action === 'import_selected') {
                 
                 // 3. Consulta INSERT CORRIGIDA
                 $sql = "INSERT INTO clientes (nome_cliente, nome_responsavel, email, telefone, canal_origem, categoria, is_prospect) VALUES (?, ?, ?, ?, ?, ?, ?)";
-                $pdo->prepare($sql)->execute([$nome_cliente, $nome_responsavel, $email, $telefone, 'Bitrix24', 'Entrada', 1]);
+                $pdo->prepare($sql)->execute([$nome_cliente, $nome_responsavel, $email, $telefone, 'Bitrix24', LeadCategory::DEFAULT, 1]);
                 $count_adicionados++;
 
             } catch (PDOException $e) {

--- a/crm/clientes/novo.php
+++ b/crm/clientes/novo.php
@@ -62,17 +62,6 @@ if (strpos($redirectUrl, APP_URL) !== 0) {
                     <input type="tel" name="telefone" id="telefone" autocomplete="tel" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
                 </div>
 
-                <div class="md:col-span-2">
-                    <label for="categoria" class="block text-sm font-medium text-gray-700">Categoria do Lead</label>
-                    <select name="categoria" id="categoria" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
-                        <option value="Entrada">Entrada</option>
-                        <option value="Qualificado">Qualificado</option>
-                        <option value="Com Orçamento">Com Orçamento</option>
-                        <option value="Em Negociação">Em Negociação</option>
-                        <option value="Cliente Ativo">Lead Ativo</option>
-                        <option value="Sem Interesse">Sem Interesse</option>
-                    </select>
-                </div>
             </div>
 
             <div class="pt-5 flex justify-end border-t mt-6">

--- a/crm/clientes/salvar.php
+++ b/crm/clientes/salvar.php
@@ -4,6 +4,7 @@
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
 require_once __DIR__ . '/../../app/utils/PhoneUtils.php';
+require_once __DIR__ . '/../../app/utils/LeadCategory.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
@@ -17,7 +18,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $email = trim($_POST['email']);
     $telefone = trim($_POST['telefone']);
     $canal_origem = trim($_POST['canal_origem']);
-    $categoria = trim($_POST['categoria']);
     $redirectUrl = $id ? APP_URL . "/crm/clientes/editar_cliente.php?id=$id" : APP_URL . "/crm/clientes/novo.php";
 
     // Validação
@@ -62,14 +62,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 exit();
             }
 
-            $sql = "UPDATE clientes SET nome_cliente = :nome_cliente, nome_responsavel = :nome_responsavel, email = :email, telefone = :telefone, canal_origem = :canal_origem, categoria = :categoria, is_prospect = :is_prospect WHERE id = :id";
+            $sql = "UPDATE clientes SET nome_cliente = :nome_cliente, nome_responsavel = :nome_responsavel, email = :email, telefone = :telefone, canal_origem = :canal_origem, is_prospect = :is_prospect WHERE id = :id";
             $params = [
                 ':nome_cliente' => $nome_cliente,
                 ':nome_responsavel' => $nome_responsavel,
                 ':email' => $email,
                 ':telefone' => $telefone,
                 ':canal_origem' => $canal_origem,
-                ':categoria' => $categoria,
                 ':is_prospect' => 1,
                 ':id' => $id
             ];
@@ -88,7 +87,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 ':email' => $email,
                 ':telefone' => $telefone,
                 ':canal_origem' => $canal_origem,
-                ':categoria' => $categoria,
+                ':categoria' => LeadCategory::DEFAULT,
                 ':is_prospect' => 1,
                 ':crm_owner_id' => $currentUserId
             ];

--- a/crm/prospeccoes/atualizar.php
+++ b/crm/prospeccoes/atualizar.php
@@ -3,6 +3,7 @@
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
+require_once __DIR__ . '/../../app/utils/LeadCategory.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     header('Location: ' . APP_URL . '/crm/prospeccoes/lista.php');
@@ -38,14 +39,23 @@ try {
 
     } elseif ($action === 'update_prospect') {
 
+        $leadCategory = $_POST['lead_category'] ?? LeadCategory::DEFAULT;
+        if (!LeadCategory::isValid(is_string($leadCategory) ? trim($leadCategory) : null)) {
+            $leadCategory = LeadCategory::DEFAULT;
+        } else {
+            $leadCategory = trim($leadCategory);
+        }
+
         $new_data = [
             'data_reuniao_agendada' => !empty($_POST['data_reuniao_agendada']) ? $_POST['data_reuniao_agendada'] : null,
-            'reuniao_compareceu' => isset($_POST['reuniao_compareceu']) ? 1 : 0
+            'reuniao_compareceu' => isset($_POST['reuniao_compareceu']) ? 1 : 0,
+            'lead_category' => $leadCategory
         ];
 
         $sql_update = "UPDATE prospeccoes SET
                             data_reuniao_agendada = :data_reuniao_agendada,
-                            reuniao_compareceu = :reuniao_compareceu
+                            reuniao_compareceu = :reuniao_compareceu,
+                            leadCategory = :lead_category
                         WHERE id = :id";
         $stmt_update = $pdo->prepare($sql_update);
         $stmt_update->execute(array_merge($new_data, ['id' => $prospeccao_id]));

--- a/crm/prospeccoes/detalhes.php
+++ b/crm/prospeccoes/detalhes.php
@@ -3,6 +3,7 @@
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
+require_once __DIR__ . '/../../app/utils/LeadCategory.php';
 
 $user_perfil = $_SESSION['user_perfil'];
 $prospeccao_id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
@@ -51,6 +52,9 @@ try {
         exit;
     }
 
+    $leadCategories = LeadCategory::all();
+    $currentLeadCategory = $prospect['leadCategory'] ?? LeadCategory::DEFAULT;
+
     // A busca de interações também está correta
     $stmt_interacoes = $pdo->prepare("
         SELECT i.observacao, i.data_interacao, i.tipo, u.nome_completo AS usuario_nome 
@@ -88,15 +92,16 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                     $clienteTelefone = $prospect['cliente_telefone'] ?? '';
                     $canalOrigem = $prospect['cliente_canal_origem'] ?? '';
                     $statusAtual = $prospect['status'] ?? '';
+                    $leadCategory = $currentLeadCategory;
                 ?>
                 <div class="flex justify-between items-start mb-6">
-                    <?php $leadResponsavelNome = $prospect['lead_responsavel_nome'] ?? $prospect['nome_prospecto'] ?? ''; ?>
                     <div>
                         <h2 class="text-2xl font-bold text-gray-900"><?php echo htmlspecialchars($leadNome); ?></h2>
                         <p class="text-sm text-gray-500">Responsável: <span class="font-medium text-indigo-600"><?php echo htmlspecialchars($leadResponsavelNome); ?></span></p>
                         <?php if (!empty($statusAtual)): ?>
                             <span class="inline-flex mt-2 items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-800 uppercase tracking-wide"><?php echo htmlspecialchars($statusAtual); ?></span>
                         <?php endif; ?>
+                        <span class="inline-flex mt-2 items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-700"><?php echo htmlspecialchars($leadCategory); ?></span>
                     </div>
 
                     <div class="flex items-center space-x-2">
@@ -141,6 +146,10 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                             <label class="block text-xs font-semibold text-gray-500 uppercase tracking-wide">Origem da Chamada</label>
                             <input type="text" value="<?php echo htmlspecialchars($canalOrigem); ?>" class="mt-1 block w-full border border-gray-200 rounded-md shadow-sm py-2 px-3 bg-white text-gray-700" disabled>
                         </div>
+                        <div>
+                            <label class="block text-xs font-semibold text-gray-500 uppercase tracking-wide">Categoria do Lead</label>
+                            <input type="text" value="<?php echo htmlspecialchars($leadCategory); ?>" class="mt-1 block w-full border border-gray-200 rounded-md shadow-sm py-2 px-3 bg-white text-gray-700" disabled>
+                        </div>
                     </div>
                 </div>
 
@@ -148,6 +157,16 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                     <input type="hidden" name="prospeccao_id" value="<?php echo $prospect['id']; ?>">
                     <input type="hidden" name="action" value="update_prospect">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div>
+                            <label for="lead_category" class="block text-sm font-medium text-gray-700">Categoria do Lead</label>
+                            <select name="lead_category" id="lead_category" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+                                <?php foreach ($leadCategories as $category): ?>
+                                    <option value="<?php echo htmlspecialchars($category); ?>" <?php echo $category === $leadCategory ? 'selected' : ''; ?>>
+                                        <?php echo htmlspecialchars($category); ?>
+                                    </option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
                         <div>
                             <label for="data_reuniao_agendada" class="block text-sm font-medium text-gray-700">Data da Reunião</label>
                             <input type="datetime-local" name="data_reuniao_agendada" id="data_reuniao_agendada" value="<?php echo !empty($prospect['data_reuniao_agendada']) ? htmlspecialchars(formatSaoPauloDate($prospect['data_reuniao_agendada'], 'Y-m-d\TH:i')) : ''; ?>" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">

--- a/crm/prospeccoes/kanban.php
+++ b/crm/prospeccoes/kanban.php
@@ -3,6 +3,7 @@ require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
 require_once __DIR__ . '/../../app/models/Prospeccao.php';
 require_once __DIR__ . '/../../app/services/KanbanConfigService.php';
+require_once __DIR__ . '/../../app/utils/LeadCategory.php';
 require_once __DIR__ . '/../../app/views/layouts/header.php';
 
 $kanbanConfigService = new KanbanConfigService($pdo);
@@ -285,6 +286,8 @@ $defaultKanbanDestination = $kanbanColumns[0] ?? '';
                                 <div>
                                     <p class="font-semibold text-sm text-gray-800"><?php echo htmlspecialchars($lead['nome_prospecto']); ?></p>
                                     <p class="text-xs text-gray-600 mt-1"><?php echo htmlspecialchars($lead['nome_cliente'] ?? 'Lead não associado'); ?></p>
+                                    <?php $leadCategory = $lead['leadCategory'] ?? LeadCategory::DEFAULT; ?>
+                                    <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-[0.65rem] font-medium text-gray-700 mt-1"><?php echo htmlspecialchars($leadCategory); ?></span>
                                     <?php if (!empty($lead['responsavel_nome'])): ?>
                                         <p class="text-xs text-gray-500 mt-1">Vendedor: <?php echo htmlspecialchars($lead['responsavel_nome']); ?></p>
                                     <?php endif; ?>
@@ -331,6 +334,8 @@ $defaultKanbanDestination = $kanbanColumns[0] ?? '';
                                 <div class="flex-1">
                                     <p class="font-semibold text-sm text-gray-900"><?php echo htmlspecialchars($lead['nome_prospecto']); ?></p>
                                     <p class="text-xs text-gray-500">Status atual: <?php echo htmlspecialchars($lead['status'] ?? 'Sem status'); ?></p>
+                                    <?php $leadCategory = $lead['leadCategory'] ?? LeadCategory::DEFAULT; ?>
+                                    <p class="text-xs text-gray-500">Categoria: <?php echo htmlspecialchars($leadCategory); ?></p>
                                     <?php if (!empty($lead['responsavel_nome'])): ?>
                                         <p class="text-xs text-gray-500">Vendedor: <?php echo htmlspecialchars($lead['responsavel_nome']); ?></p>
                                     <?php endif; ?>

--- a/crm/prospeccoes/lista.php
+++ b/crm/prospeccoes/lista.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
+require_once __DIR__ . '/../../app/utils/LeadCategory.php';
 
 $pageTitle = "Lista de Prospecções";
 
@@ -173,6 +174,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                 <tr>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Prospecto</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Lead</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Categoria</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
                     <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Valor</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Responsável</th>
@@ -190,6 +192,12 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                         <tr>
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"><?php echo htmlspecialchars($prospeccao['nome_prospecto']); ?></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600"><?php echo htmlspecialchars($prospeccao['nome_cliente'] ?? 'Lead não vinculado'); ?></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                <?php $leadCategory = $prospeccao['leadCategory'] ?? LeadCategory::DEFAULT; ?>
+                                <span class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700">
+                                    <?php echo htmlspecialchars($leadCategory); ?>
+                                </span>
+                            </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                                 <span class="
                                     <?php 

--- a/crm/prospeccoes/nova.php
+++ b/crm/prospeccoes/nova.php
@@ -3,8 +3,10 @@
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
+require_once __DIR__ . '/../../app/utils/LeadCategory.php';
 
 try {
+    $leadCategories = LeadCategory::all();
     $userPerfil = $_SESSION['user_perfil'] ?? '';
     $userId = (int)($_SESSION['user_id'] ?? 0);
 
@@ -86,6 +88,17 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                         Novo Lead
                     </a>
                 </div>
+            </div>
+
+            <div>
+                <label for="lead_category" class="block text-sm font-medium text-gray-700">Categoria do Lead</label>
+                <select name="lead_category" id="lead_category" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+                    <?php foreach ($leadCategories as $category): ?>
+                        <option value="<?php echo htmlspecialchars($category); ?>" <?php echo $category === LeadCategory::DEFAULT ? 'selected' : ''; ?>>
+                            <?php echo htmlspecialchars($category); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
             </div>
 
             <div class="flex justify-end pt-4">

--- a/crm/prospeccoes/salvar.php
+++ b/crm/prospeccoes/salvar.php
@@ -3,10 +3,18 @@
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
+require_once __DIR__ . '/../../app/utils/LeadCategory.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     $cliente_id = filter_input(INPUT_POST, 'cliente_id', FILTER_VALIDATE_INT);
+    $lead_category = $_POST['lead_category'] ?? LeadCategory::DEFAULT;
+    if (!LeadCategory::isValid(is_string($lead_category) ? trim($lead_category) : null)) {
+        $lead_category = LeadCategory::DEFAULT;
+    } else {
+        $lead_category = trim($lead_category);
+    }
+
     $responsavel_id = $_SESSION['user_id'];
     $userPerfil = $_SESSION['user_perfil'] ?? '';
     $data_prospeccao = date('Y-m-d H:i:s');
@@ -52,13 +60,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     $pdo->beginTransaction();
     try {
-        $sql = "INSERT INTO prospeccoes (cliente_id, nome_prospecto, data_prospeccao, responsavel_id, feedback_inicial, valor_proposto, status) VALUES (:cliente_id, :nome_prospecto, :data_prospeccao, :responsavel_id, :feedback_inicial, :valor_proposto, :status)";
+        $sql = "INSERT INTO prospeccoes (cliente_id, nome_prospecto, data_prospeccao, responsavel_id, feedback_inicial, valor_proposto, status, leadCategory) VALUES (:cliente_id, :nome_prospecto, :data_prospeccao, :responsavel_id, :feedback_inicial, :valor_proposto, :status, :lead_category)";
         $stmt = $pdo->prepare($sql);
         $stmt->execute([
             ':cliente_id' => $cliente_id, ':nome_prospecto' => $nome_prospecto,
             ':data_prospeccao' => $data_prospeccao, ':responsavel_id' => $responsavel_id,
             ':feedback_inicial' => '', ':valor_proposto' => 0,
-            ':status' => 'Cliente ativo'
+            ':status' => 'Cliente ativo', ':lead_category' => $lead_category
         ]);
         $prospeccao_id = $pdo->lastInsertId();
 

--- a/crm/prospeccoes/salvar_prospeccao_simulado.php
+++ b/crm/prospeccoes/salvar_prospeccao_simulado.php
@@ -3,6 +3,7 @@
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
+require_once __DIR__ . '/../../app/utils/LeadCategory.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     
@@ -11,8 +12,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $valor_proposto = filter_input(INPUT_POST, 'valor_proposto', FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
     $feedback_inicial = trim($_POST['feedback_inicial']);
     $status = trim($_POST['status']);
-    
-    $responsavel_id = $_SESSION['user_id']; 
+    $leadCategory = $_POST['lead_category'] ?? LeadCategory::DEFAULT;
+    if (!LeadCategory::isValid(is_string($leadCategory) ? trim($leadCategory) : null)) {
+        $leadCategory = LeadCategory::DEFAULT;
+    } else {
+        $leadCategory = trim($leadCategory);
+    }
+
+    $responsavel_id = $_SESSION['user_id'];
     $data_prospeccao = date('Y-m-d H:i:s');
 
     if (empty($cliente_id) || empty($nome_prospecto) || !isset($_POST['valor_proposto']) || empty($feedback_inicial) || empty($status)) {
@@ -22,13 +29,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
     
     try {
-        $sql = "INSERT INTO prospeccoes 
-                    (cliente_id, nome_prospecto, data_prospeccao, responsavel_id, feedback_inicial, valor_proposto, status) 
-                VALUES 
-                    (:cliente_id, :nome_prospecto, :data_prospeccao, :responsavel_id, :feedback_inicial, :valor_proposto, :status)";
+        $sql = "INSERT INTO prospeccoes
+                    (cliente_id, nome_prospecto, data_prospeccao, responsavel_id, feedback_inicial, valor_proposto, status, leadCategory)
+                VALUES
+                    (:cliente_id, :nome_prospecto, :data_prospeccao, :responsavel_id, :feedback_inicial, :valor_proposto, :status, :lead_category)";
 
         $stmt = $pdo->prepare($sql);
-        
+
         $stmt->execute([
             ':cliente_id' => $cliente_id,
             ':nome_prospecto' => $nome_prospecto,
@@ -36,7 +43,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':responsavel_id' => $responsavel_id,
             ':feedback_inicial' => $feedback_inicial,
             ':valor_proposto' => $valor_proposto,
-            ':status' => $status
+            ':status' => $status,
+            ':lead_category' => $leadCategory
         ]);
 
         $prospeccao_id = $pdo->lastInsertId();

--- a/database-migrations.md
+++ b/database-migrations.md
@@ -79,6 +79,17 @@ UPDATE `processos`
  WHERE `status_processo` IN ('Arquivado','Arquivada','Recusado','Recusada');
 ```
 
+## 6. Ajustes na tabela `prospeccoes`
+
+```sql
+ALTER TABLE `prospeccoes`
+  ADD COLUMN `leadCategory` VARCHAR(60) NOT NULL DEFAULT 'Entrada' AFTER `status`;
+
+UPDATE `prospeccoes`
+   SET `leadCategory` = 'Entrada'
+ WHERE `leadCategory` IS NULL OR `leadCategory` = '';
+```
+
 ## Exemplos de uso
 
 A tabela abaixo demonstra comandos básicos utilizando os novos campos.


### PR DESCRIPTION
## Summary
- centralize the list of allowed lead categories and the default value in a shared utility
- default new leads and imports to the Entrada category while removing the manual field from lead forms
- expose lead category selection and display across prospection creation, details, list view, and kanban cards

## Testing
- `for file in app/utils/LeadCategory.php crm/clientes/novo.php crm/clientes/editar_cliente.php crm/clientes/salvar.php crm/clientes/integracao_bitrix.php crm/clientes/importar.php crm/clientes/importar_processar.php crm/prospeccoes/nova.php crm/prospeccoes/salvar.php crm/prospeccoes/salvar_prospeccao_simulado.php crm/prospeccoes/lista.php crm/prospeccoes/detalhes.php crm/prospeccoes/atualizar.php crm/prospeccoes/kanban.php app/models/Prospeccao.php; do
    php -l "$file" || break
done`


------
https://chatgpt.com/codex/tasks/task_e_68e1b362721c8330998e369eb190a8fd