### PR TITLE
Atualiza painel de TV com tema alternável e melhorias visuais

### DIFF
--- a/app/controllers/AdminController.php
+++ b/app/controllers/AdminController.php
@@ -87,7 +87,7 @@ class AdminController
             'due_soon_color' => 'bg-yellow-200 text-yellow-800',
             'on_track_color' => 'text-green-600',
             'refresh_interval' => 60,
-            'orientation' => 'portrait',
+            'color_scheme' => 'dark',
             'enable_progress_bar' => true,
             'enable_alert_pulse' => true,
         ];
@@ -102,7 +102,7 @@ class AdminController
 
         $validIntervals = [60, 180, 300];
         $defaults['refresh_interval'] = in_array((int) $defaults['refresh_interval'], $validIntervals, true) ? (int) $defaults['refresh_interval'] : 60;
-        $defaults['orientation'] = in_array($defaults['orientation'], ['portrait', 'landscape'], true) ? $defaults['orientation'] : 'portrait';
+        $defaults['color_scheme'] = in_array($defaults['color_scheme'], ['dark', 'light'], true) ? $defaults['color_scheme'] : 'dark';
         $defaults['enable_progress_bar'] = (bool) $defaults['enable_progress_bar'];
         $defaults['enable_alert_pulse'] = (bool) $defaults['enable_alert_pulse'];
 
@@ -125,8 +125,10 @@ class AdminController
             'on_track' => $settings['on_track_color'],
         ];
         $processes = $this->processoModel->getProcessesForTvPanel();
-        $bodyClass = 'tv-panel-page bg-slate-900 text-white';
-        $orientationClass = $settings['orientation'] === 'landscape' ? 'tv-panel-landscape' : 'tv-panel-portrait';
+        $bodyClass = $settings['color_scheme'] === 'light'
+            ? 'tv-panel-page bg-white text-slate-900'
+            : 'tv-panel-page bg-slate-900 text-white';
+        $theme = $settings['color_scheme'];
 
         require_once __DIR__ . '/../views/layouts/header.php';
         require_once __DIR__ . '/../views/admin/tv_painel.php';
@@ -158,7 +160,7 @@ class AdminController
             'due_soon_color' => trim($_POST['due_soon_color'] ?? $current['due_soon_color']),
             'on_track_color' => trim($_POST['on_track_color'] ?? $current['on_track_color']),
             'refresh_interval' => (int) ($_POST['refresh_interval'] ?? $current['refresh_interval']),
-            'orientation' => $_POST['orientation'] ?? $current['orientation'],
+            'color_scheme' => $_POST['color_scheme'] ?? $current['color_scheme'],
             'enable_progress_bar' => isset($_POST['enable_progress_bar']),
             'enable_alert_pulse' => isset($_POST['enable_alert_pulse']),
         ];
@@ -168,8 +170,8 @@ class AdminController
             $payload['refresh_interval'] = 60;
         }
 
-        if (!in_array($payload['orientation'], ['portrait', 'landscape'], true)) {
-            $payload['orientation'] = 'portrait';
+        if (!in_array($payload['color_scheme'], ['dark', 'light'], true)) {
+            $payload['color_scheme'] = 'dark';
         }
 
         $this->persistTvPanelSettings($payload);
@@ -198,6 +200,8 @@ class AdminController
             $showActions = false;
             $showProgress = $settings['enable_progress_bar'];
             $highlightAnimations = $settings['enable_alert_pulse'];
+            $showRowStatusColors = $settings['color_scheme'] === 'light';
+            $progressTrackClass = $settings['color_scheme'] === 'light' ? 'bg-slate-200' : 'bg-slate-800';
             require __DIR__ . '/../views/dashboard/partials/process_table_rows.php';
             $htmlRows = ob_get_clean();
         } else {

--- a/app/views/admin/tv_painel.php
+++ b/app/views/admin/tv_painel.php
@@ -1,5 +1,4 @@
 <?php
-$orientationClass = $orientationClass ?? 'tv-panel-portrait';
 $refreshInterval = $settings['refresh_interval'] ?? 60;
 $progressEnabled = !empty($settings['enable_progress_bar']);
 $alertEnabled = !empty($settings['enable_alert_pulse']);
@@ -11,24 +10,25 @@ $colorConfig = [
     'due_soon' => $settings['due_soon_color'] ?? 'bg-yellow-200 text-yellow-800',
     'on_track' => $settings['on_track_color'] ?? 'text-green-600',
 ];
+$theme = $theme ?? ($settings['color_scheme'] ?? 'dark');
+$themeClass = $theme === 'light' ? 'tv-panel-theme-light' : 'tv-panel-theme-dark';
+$tableThemeClass = $theme === 'light' ? 'divide-y divide-gray-200 tv-panel-table' : 'divide-y divide-slate-800 tv-panel-table';
+$theadThemeClass = $theme === 'light' ? 'bg-gray-50 text-gray-600' : 'tv-panel-thead-dark text-slate-200';
+$tbodyThemeClass = $theme === 'light' ? 'bg-white divide-y divide-gray-200' : 'divide-y divide-slate-800 tv-panel-tbody-dark';
+$progressTrackClass = $theme === 'light' ? 'bg-slate-200' : 'bg-slate-800';
+$showRowStatusColors = $theme === 'light';
 ?>
-<div class="tv-panel-container <?php echo htmlspecialchars($orientationClass); ?>" data-tv-panel
+<div class="tv-panel-container <?php echo htmlspecialchars($themeClass); ?>" data-tv-panel
      data-endpoint="<?php echo htmlspecialchars($tvEndpoint); ?>"
      data-refresh-interval="<?php echo (int) $refreshInterval; ?>"
      data-progress-enabled="<?php echo $progressEnabled ? '1' : '0'; ?>"
      data-alert-enabled="<?php echo $alertEnabled ? '1' : '0'; ?>">
-    <header class="tv-panel-header">
-        <div class="tv-panel-title">
-            <h1 class="text-4xl font-extrabold tracking-wide">Painel Operacional</h1>
-            <p class="text-lg opacity-80">Monitoramento em tempo real dos processos ativos</p>
-        </div>
-        <div class="tv-panel-meta">
-            <div class="tv-panel-clock" data-tv-clock></div>
-            <a href="<?php echo APP_URL; ?>/admin.php?action=tv_panel_config" class="tv-panel-config-link">
-                <i class="fas fa-sliders-h mr-2"></i>Configurações
-            </a>
-        </div>
-    </header>
+    <div class="tv-panel-meta-inline">
+        <div class="tv-panel-clock" data-tv-clock></div>
+        <a href="<?php echo APP_URL; ?>/admin.php?action=tv_panel_config" class="tv-panel-config-link">
+            <i class="fas fa-sliders-h mr-2"></i>Configurações
+        </a>
+    </div>
 
     <section class="tv-panel-table-wrapper">
         <?php if (empty($processesForPartial)): ?>

--- a/app/views/admin/tv_painel_config.php
+++ b/app/views/admin/tv_painel_config.php
@@ -40,10 +40,10 @@
                     </select>
                 </div>
                 <div>
-                    <label for="orientation" class="block text-sm font-medium text-gray-700 mb-1">Orientação do monitor</label>
-                    <select id="orientation" name="orientation" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                        <option value="portrait" <?php echo ($settings['orientation'] === 'portrait') ? 'selected' : ''; ?>>Retrato (9×16)</option>
-                        <option value="landscape" <?php echo ($settings['orientation'] === 'landscape') ? 'selected' : ''; ?>>Paisagem (16×9)</option>
+                    <label for="color_scheme" class="block text-sm font-medium text-gray-700 mb-1">Tema do painel</label>
+                    <select id="color_scheme" name="color_scheme" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        <option value="dark" <?php echo ($settings['color_scheme'] === 'dark') ? 'selected' : ''; ?>>Preto (tema escuro)</option>
+                        <option value="light" <?php echo ($settings['color_scheme'] === 'light') ? 'selected' : ''; ?>>Branco (tema claro)</option>
                     </select>
                 </div>
             </div>

--- a/app/views/dashboard/partials/process_table.php
+++ b/app/views/dashboard/partials/process_table.php
@@ -3,9 +3,13 @@ $showActions = $showActions ?? true;
 $showProgress = $showProgress ?? false;
 $highlightAnimations = $highlightAnimations ?? false;
 $deadlineColors = $deadlineColors ?? [];
+$tableThemeClass = $tableThemeClass ?? 'divide-y divide-gray-200';
+$theadThemeClass = trim(($theadThemeClass ?? 'bg-gray-50') . ' sticky top-0 z-10');
+$tbodyThemeClass = $tbodyThemeClass ?? 'bg-white divide-y divide-gray-200';
+$tableClass = trim('min-w-full table-auto ' . $tableThemeClass);
 ?>
-<table class="min-w-full divide-y divide-gray-200 table-auto">
-    <thead class="bg-gray-50 sticky top-0 z-10">
+<table class="<?php echo htmlspecialchars($tableClass); ?>">
+    <thead class="<?php echo htmlspecialchars($theadThemeClass); ?>">
         <tr>
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Família</th>
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Assessoria</th>
@@ -20,7 +24,7 @@ $deadlineColors = $deadlineColors ?? [];
             <?php endif; ?>
         </tr>
     </thead>
-    <tbody class="bg-white divide-y divide-gray-200" id="processes-table-body">
+    <tbody class="<?php echo htmlspecialchars($tbodyThemeClass); ?>" id="processes-table-body">
         <?php
             $processes = $processes ?? [];
             $renderOnlyBody = false;

--- a/app/views/dashboard/partials/process_table_rows.php
+++ b/app/views/dashboard/partials/process_table_rows.php
@@ -6,16 +6,19 @@ $showActions = $showActions ?? true;
 $showProgress = $showProgress ?? false;
 $highlightAnimations = $highlightAnimations ?? false;
 $allowLinks = $allowLinks ?? true;
+$showRowStatusColors = $showRowStatusColors ?? true;
+$progressTrackClass = $progressTrackClass ?? 'bg-slate-200';
 
 foreach ($processes as $processo):
     $statusInfo = DashboardProcessFormatter::normalizeStatusInfo($processo['status_processo'] ?? '');
     $statusNormalized = $statusInfo['normalized'];
-    $rowClass = DashboardProcessFormatter::getRowClass($statusNormalized);
+    $rowClass = $showRowStatusColors ? DashboardProcessFormatter::getRowClass($statusNormalized) : '';
     $deadlineDescriptor = DashboardProcessFormatter::buildDeadlineDescriptor($processo, $deadlineColors);
     $serviceBadges = DashboardProcessFormatter::getServiceBadges($processo['categorias_servico'] ?? '');
     $deadlineClass = $deadlineDescriptor['class'];
     $deadlineLabel = $deadlineDescriptor['label'];
     $progressValue = $deadlineDescriptor['progress'];
+    $progressClass = $deadlineDescriptor['progress_class'] ?? 'bg-slate-500';
     $rowHighlight = '';
 
     if ($highlightAnimations && in_array($deadlineDescriptor['state'], ['overdue', 'due_today'], true)) {
@@ -61,14 +64,16 @@ foreach ($processes as $processo):
         <?php echo !empty($processo['data_inicio_traducao']) ? date('d/m/Y', strtotime($processo['data_inicio_traducao'])) : 'N/A'; ?>
     </td>
     <td class="px-3 py-1 whitespace-nowrap text-xs font-medium">
-        <span class="px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full <?php echo $deadlineClass; ?>">
-            <?php echo htmlspecialchars($deadlineLabel); ?>
-        </span>
-        <?php if ($showProgress && $progressValue !== null): ?>
-            <div class="mt-1 h-2 bg-slate-200 rounded-full overflow-hidden">
-                <div class="h-2 bg-slate-500" style="width: <?php echo $progressValue; ?>%"></div>
-            </div>
-        <?php endif; ?>
+        <div class="flex items-center gap-3">
+            <span class="px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full <?php echo $deadlineClass; ?>">
+                <?php echo htmlspecialchars($deadlineLabel); ?>
+            </span>
+            <?php if ($showProgress && $progressValue !== null): ?>
+                <div class="flex-1 h-2 rounded-full overflow-hidden <?php echo htmlspecialchars($progressTrackClass); ?>">
+                    <div class="h-2 <?php echo htmlspecialchars($progressClass); ?> transition-all duration-500" style="width: <?php echo $progressValue; ?>%"></div>
+                </div>
+            <?php endif; ?>
+        </div>
     </td>
     <?php if ($showActions): ?>
     <td class="px-3 py-1 whitespace-nowrap text-center text-xs font-medium">

--- a/assets/style.css
+++ b/assets/style.css
@@ -17,25 +17,17 @@
     flex-direction: column;
     gap: 1.5rem;
     min-height: calc(100vh - 4rem);
+    max-width: 1600px;
+    margin: 0 auto;
+    width: 100%;
 }
 
-.tv-panel-header {
+.tv-panel-meta-inline {
     display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    color: #f8fafc;
-}
-
-.tv-panel-title h1 {
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-}
-
-.tv-panel-meta {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 0.5rem;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 1rem;
+    align-self: flex-end;
 }
 
 .tv-panel-clock {
@@ -49,29 +41,21 @@
     gap: 0.5rem;
     padding: 0.5rem 1rem;
     border-radius: 9999px;
-    background: rgba(15, 23, 42, 0.4);
-    color: #f8fafc;
     font-weight: 600;
     text-decoration: none;
-    transition: background 0.3s ease;
-}
-
-.tv-panel-config-link:hover {
-    background: rgba(148, 163, 184, 0.4);
+    transition: background 0.3s ease, color 0.3s ease;
 }
 
 .tv-panel-table-wrapper {
     flex: 1;
     overflow: hidden;
     border-radius: 1rem;
-    background: rgba(15, 23, 42, 0.35);
     padding: 1rem;
 }
 
 .tv-panel-table-wrapper table {
     width: 100%;
     font-size: 1.05rem;
-    color: #0f172a;
 }
 
 .tv-panel-table-wrapper th,
@@ -84,7 +68,6 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    color: #cbd5f5;
     font-size: 1rem;
 }
 
@@ -94,17 +77,6 @@
     justify-content: center;
     min-height: 60vh;
     font-size: 2rem;
-    color: #e2e8f0;
-}
-
-.tv-panel-portrait {
-    max-width: 1200px;
-    margin: 0 auto;
-}
-
-.tv-panel-landscape {
-    max-width: 1600px;
-    margin: 0 auto;
 }
 
 .tv-panel-page .min-w-full tbody tr td,
@@ -119,4 +91,73 @@
 
 .tv-panel-page .min-w-full tbody tr td span {
     font-size: 0.95rem;
+}
+
+.tv-panel-theme-dark .tv-panel-config-link {
+    background: rgba(15, 23, 42, 0.6);
+    color: #f8fafc;
+}
+
+.tv-panel-theme-dark .tv-panel-config-link:hover {
+    background: rgba(148, 163, 184, 0.4);
+}
+
+.tv-panel-theme-light .tv-panel-config-link {
+    background: rgba(226, 232, 240, 0.85);
+    color: #0f172a;
+}
+
+.tv-panel-theme-light .tv-panel-config-link:hover {
+    background: rgba(148, 163, 184, 0.6);
+}
+
+.tv-panel-theme-dark .tv-panel-table-wrapper {
+    background: rgba(15, 23, 42, 0.65);
+    box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.65);
+}
+
+.tv-panel-theme-light .tv-panel-table-wrapper {
+    background: rgba(241, 245, 249, 0.85);
+    box-shadow: 0 20px 45px -10px rgba(148, 163, 184, 0.35);
+}
+
+.tv-panel-theme-dark .tv-panel-footer {
+    color: #cbd5f5;
+}
+
+.tv-panel-theme-light .tv-panel-footer {
+    color: #0f172a;
+}
+
+.tv-panel-theme-dark .tv-panel-empty {
+    color: #e2e8f0;
+}
+
+.tv-panel-theme-light .tv-panel-empty {
+    color: #475569;
+}
+
+.tv-panel-theme-dark .tv-panel-table th,
+.tv-panel-theme-dark .tv-panel-table td {
+    color: #e2e8f0 !important;
+}
+
+.tv-panel-thead-dark {
+    background-color: rgba(30, 41, 59, 0.85);
+}
+
+.tv-panel-tbody-dark tr:nth-child(odd) {
+    background-color: rgba(15, 23, 42, 0.75);
+}
+
+.tv-panel-tbody-dark tr:nth-child(even) {
+    background-color: rgba(30, 41, 59, 0.75);
+}
+
+.tv-panel-tbody-dark tr:hover {
+    background-color: rgba(51, 65, 85, 0.85);
+}
+
+.tv-panel-theme-dark .tv-panel-table tbody tr td {
+    border-color: rgba(148, 163, 184, 0.2);
 }


### PR DESCRIPTION
## Resumo
- remove a configuração de orientação do monitor e adiciona seleção de tema claro/escuro para o painel de TV
- ajusta o layout do painel para ocultar o cabeçalho, alinhar relógio/configuração e harmonizar a tabela com o tema escolhido
- sincroniza a barra de progresso com a cor do prazo e aprimora as opções do formatter para suportar as novas cores

## Testes
- php -l app/controllers/AdminController.php
- php -l app/views/admin/tv_painel.php
- php -l app/views/admin/tv_painel_config.php
- php -l app/views/dashboard/partials/process_table.php
- php -l app/views/dashboard/partials/process_table_rows.php
- php -l app/utils/DashboardProcessFormatter.php


------
https://chatgpt.com/codex/tasks/task_e_68e1ca3323b88330a7f779fc63d3224d