### PR TITLE
Ajusta barra de progresso do painel de TV

### DIFF
--- a/app/views/dashboard/partials/process_table.php
+++ b/app/views/dashboard/partials/process_table.php
@@ -19,6 +19,9 @@ $tableClass = trim('min-w-full table-auto ' . $tableThemeClass);
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Entrada</th>
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Envio</th>
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Prazo</th>
+            <?php if ($showProgress): ?>
+                <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Progresso</th>
+            <?php endif; ?>
             <?php if ($showActions): ?>
                 <th scope="col" class="relative px-3 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
             <?php endif; ?>

--- a/app/views/dashboard/partials/process_table_rows.php
+++ b/app/views/dashboard/partials/process_table_rows.php
@@ -18,6 +18,16 @@ foreach ($processes as $processo):
     $progressValue = $deadlineDescriptor['progress'];
     $rowHighlight = '';
 
+    $deadlineClassParts = preg_split('/\s+/', trim((string) $deadlineClass));
+    $deadlineBgClass = null;
+
+    foreach ($deadlineClassParts as $classPart) {
+        if (strpos($classPart, 'bg-') === 0) {
+            $deadlineBgClass = $classPart;
+            break;
+        }
+    }
+
     if ($highlightAnimations && in_array($deadlineDescriptor['state'], ['overdue', 'due_today'], true)) {
         $rowHighlight = 'animate-pulse';
     }
@@ -60,12 +70,20 @@ foreach ($processes as $processo):
         <span class="px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full <?php echo $deadlineClass; ?>">
             <?php echo htmlspecialchars($deadlineLabel); ?>
         </span>
-        <?php if ($showProgress && $progressValue !== null): ?>
-            <div class="mt-1 h-2 bg-slate-200 rounded-full overflow-hidden">
-                <div class="h-2 bg-slate-500" style="width: <?php echo $progressValue; ?>%"></div>
-            </div>
-        <?php endif; ?>
     </td>
+    <?php if ($showProgress): ?>
+        <td class="px-3 py-1 text-xs font-medium">
+            <?php if ($progressValue !== null): ?>
+                <div class="tv-panel-progress-wrapper">
+                    <div class="tv-panel-progress-track">
+                        <div class="tv-panel-progress-fill <?php echo htmlspecialchars($deadlineBgClass ?? 'bg-slate-500'); ?>" style="width: <?php echo $progressValue; ?>%"></div>
+                    </div>
+                </div>
+            <?php else: ?>
+                <span class="text-gray-400">N/A</span>
+            <?php endif; ?>
+        </td>
+    <?php endif; ?>
     <?php if ($showActions): ?>
     <td class="px-3 py-1 whitespace-nowrap text-center text-xs font-medium">
         <div class="relative inline-block p-1">

--- a/assets/style.css
+++ b/assets/style.css
@@ -53,6 +53,24 @@
     padding: 1rem;
 }
 
+.tv-panel-progress-wrapper {
+    display: flex;
+    align-items: center;
+    width: 100%;
+}
+
+.tv-panel-progress-track {
+    background-color: rgba(148, 163, 184, 0.35);
+    border-radius: 9999px;
+    height: 0.75rem;
+    overflow: hidden;
+    width: min(98vw, 98%);
+}
+
+.tv-panel-progress-fill {
+    height: 100%;
+}
+
 .tv-panel-table-wrapper table {
     width: 100%;
     font-size: 1.05rem;


### PR DESCRIPTION
## Resumo
- adiciona uma coluna exclusiva para exibir o progresso no painel de TV
- harmoniza a cor da barra de progresso com o indicador de prazo e amplia a largura para 98% da tela
- cria estilos específicos para o novo layout do componente de progresso

## Testes
- não aplicável

------
https://chatgpt.com/codex/tasks/task_e_68e1d05c486483309226d028e92be252