### PR TITLE
Ajusta gestão da categoria do lead para prospecções

### DIFF
--- a/crm/clientes/editar_cliente.php
+++ b/crm/clientes/editar_cliente.php
@@ -89,17 +89,6 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                     <option value="Outro" <?php echo ($cliente['canal_origem'] == 'Outro') ? 'selected' : ''; ?>>Outro</option>
                 </select>
             </div>
-            <div>
-                <label for="categoria" class="block text-sm font-medium text-gray-700">Categoria</label>
-                <select name="categoria" id="categoria" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
-                    <option value="Entrada" <?php echo ($cliente['categoria'] == 'Entrada') ? 'selected' : ''; ?>>Entrada</option>
-                    <option value="Qualificado" <?php echo ($cliente['categoria'] == 'Qualificado') ? 'selected' : ''; ?>>Qualificado</option>
-                    <option value="Com Orçamento" <?php echo ($cliente['categoria'] == 'Com Orçamento') ? 'selected' : ''; ?>>Com Orçamento</option>
-                    <option value="Em Negociação" <?php echo ($cliente['categoria'] == 'Em Negociação') ? 'selected' : ''; ?>>Em Negociação</option>
-                    <option value="Cliente Ativo" <?php echo ($cliente['categoria'] == 'Cliente Ativo') ? 'selected' : ''; ?>>Lead Ativo</option>
-                    <option value="Sem Interesse" <?php echo ($cliente['categoria'] == 'Sem Interesse') ? 'selected' : ''; ?>>Sem Interesse</option>
-                </select>
-            </div>
         </div>
 
         <div class="pt-5 flex justify-between items-center border-t border-gray-200 mt-6">

--- a/crm/clientes/importar.php
+++ b/crm/clientes/importar.php
@@ -21,17 +21,7 @@ $channelOptions = [
     'Outro'
 ];
 
-$categoryOptions = [
-    'Entrada',
-    'Qualificado',
-    'Com Orçamento',
-    'Em Negociação',
-    'Cliente Ativo',
-    'Sem Interesse'
-];
-
 $defaultChannel = 'Outro';
-$defaultCategory = 'Entrada';
 
 $assignedOwnerId = $currentUserPerfil === 'vendedor' ? $currentUserId : null;
 $vendors = $currentUserPerfil === 'vendedor' ? [] : $userModel->getActiveVendors();
@@ -59,15 +49,6 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                     <select id="default_channel" name="default_channel" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
                         <?php foreach ($channelOptions as $channel): ?>
                             <option value="<?php echo htmlspecialchars($channel); ?>" <?php echo $channel === $defaultChannel ? 'selected' : ''; ?>><?php echo htmlspecialchars($channel); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </div>
-
-                <div>
-                    <label for="default_category" class="block text-sm font-medium text-gray-700">Categoria padrão</label>
-                    <select id="default_category" name="default_category" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
-                        <?php foreach ($categoryOptions as $category): ?>
-                            <option value="<?php echo htmlspecialchars($category); ?>" <?php echo $category === $defaultCategory ? 'selected' : ''; ?>><?php echo htmlspecialchars($category); ?></option>
                         <?php endforeach; ?>
                     </select>
                 </div>

--- a/crm/clientes/importar_processar.php
+++ b/crm/clientes/importar_processar.php
@@ -35,23 +35,9 @@ $channelOptions = [
     'Outro'
 ];
 
-$categoryOptions = [
-    'Entrada',
-    'Qualificado',
-    'Com Orçamento',
-    'Em Negociação',
-    'Cliente Ativo',
-    'Sem Interesse'
-];
-
 $defaultChannel = $_POST['default_channel'] ?? 'Outro';
 if (!in_array($defaultChannel, $channelOptions, true)) {
     $defaultChannel = 'Outro';
-}
-
-$defaultCategory = $_POST['default_category'] ?? 'Entrada';
-if (!in_array($defaultCategory, $categoryOptions, true)) {
-    $defaultCategory = 'Entrada';
 }
 
 $delimiter = $_POST['delimiter'] ?? ';';
@@ -160,7 +146,7 @@ try {
             ':email' => $email !== '' ? $email : null,
             ':telefone' => $telefoneRaw !== '' ? $telefoneRaw : null,
             ':canal_origem' => $defaultChannel,
-            ':categoria' => $defaultCategory,
+            ':categoria' => 'Entrada',
             ':crm_owner_id' => $assignedOwnerId,
         ]);
 

--- a/crm/clientes/novo.php
+++ b/crm/clientes/novo.php
@@ -62,17 +62,6 @@ if (strpos($redirectUrl, APP_URL) !== 0) {
                     <input type="tel" name="telefone" id="telefone" autocomplete="tel" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
                 </div>
 
-                <div class="md:col-span-2">
-                    <label for="categoria" class="block text-sm font-medium text-gray-700">Categoria do Lead</label>
-                    <select name="categoria" id="categoria" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
-                        <option value="Entrada">Entrada</option>
-                        <option value="Qualificado">Qualificado</option>
-                        <option value="Com Orçamento">Com Orçamento</option>
-                        <option value="Em Negociação">Em Negociação</option>
-                        <option value="Cliente Ativo">Lead Ativo</option>
-                        <option value="Sem Interesse">Sem Interesse</option>
-                    </select>
-                </div>
             </div>
 
             <div class="pt-5 flex justify-end border-t mt-6">

--- a/crm/clientes/salvar.php
+++ b/crm/clientes/salvar.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $email = trim($_POST['email']);
     $telefone = trim($_POST['telefone']);
     $canal_origem = trim($_POST['canal_origem']);
-    $categoria = trim($_POST['categoria']);
+    $leadCategory = 'Entrada';
     $redirectUrl = $id ? APP_URL . "/crm/clientes/editar_cliente.php?id=$id" : APP_URL . "/crm/clientes/novo.php";
 
     // Validação
@@ -40,7 +40,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     try {
         if ($id) {
-            $stmtCheckProspect = $pdo->prepare("SELECT is_prospect, crmOwnerId FROM clientes WHERE id = :id");
+            $stmtCheckProspect = $pdo->prepare("SELECT is_prospect, crmOwnerId, categoria FROM clientes WHERE id = :id");
             $stmtCheckProspect->execute([':id' => $id]);
             $clienteExistente = $stmtCheckProspect->fetch(PDO::FETCH_ASSOC);
 
@@ -56,6 +56,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 exit();
             }
 
+            if (!empty($clienteExistente['categoria'])) {
+                $leadCategory = $clienteExistente['categoria'];
+            }
+
             if ((int) ($clienteExistente['is_prospect'] ?? 0) !== 1) {
                 $_SESSION['error_message'] = "Este lead já foi convertido em cliente e deve ser gerenciado pelo sistema principal.";
                 header('Location: ' . APP_URL . '/crm/clientes/lista.php');
@@ -69,7 +73,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 ':email' => $email,
                 ':telefone' => $telefone,
                 ':canal_origem' => $canal_origem,
-                ':categoria' => $categoria,
+                ':categoria' => $leadCategory,
                 ':is_prospect' => 1,
                 ':id' => $id
             ];
@@ -88,7 +92,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 ':email' => $email,
                 ':telefone' => $telefone,
                 ':canal_origem' => $canal_origem,
-                ':categoria' => $categoria,
+                ':categoria' => $leadCategory,
                 ':is_prospect' => 1,
                 ':crm_owner_id' => $currentUserId
             ];

--- a/crm/prospeccoes/atualizar.php
+++ b/crm/prospeccoes/atualizar.php
@@ -38,14 +38,22 @@ try {
 
     } elseif ($action === 'update_prospect') {
 
+        $allowedLeadCategories = ['Entrada', 'Qualificado', 'Com Orçamento', 'Em Negociação', 'Cliente Ativo', 'Sem Interesse'];
+        $leadCategory = $_POST['lead_category'] ?? 'Entrada';
+        if (!in_array($leadCategory, $allowedLeadCategories, true)) {
+            $leadCategory = 'Entrada';
+        }
+
         $new_data = [
             'data_reuniao_agendada' => !empty($_POST['data_reuniao_agendada']) ? $_POST['data_reuniao_agendada'] : null,
-            'reuniao_compareceu' => isset($_POST['reuniao_compareceu']) ? 1 : 0
+            'reuniao_compareceu' => isset($_POST['reuniao_compareceu']) ? 1 : 0,
+            'lead_category' => $leadCategory
         ];
 
         $sql_update = "UPDATE prospeccoes SET
                             data_reuniao_agendada = :data_reuniao_agendada,
-                            reuniao_compareceu = :reuniao_compareceu
+                            reuniao_compareceu = :reuniao_compareceu,
+                            leadCategory = :lead_category
                         WHERE id = :id";
         $stmt_update = $pdo->prepare($sql_update);
         $stmt_update->execute(array_merge($new_data, ['id' => $prospeccao_id]));

--- a/crm/prospeccoes/detalhes.php
+++ b/crm/prospeccoes/detalhes.php
@@ -66,6 +66,12 @@ try {
     die("Erro ao carregar dados da prospecção: " . $e->getMessage());
 }
 
+$leadCategories = ['Entrada', 'Qualificado', 'Com Orçamento', 'Em Negociação', 'Cliente Ativo', 'Sem Interesse'];
+$currentLeadCategory = $prospect['leadCategory'] ?? 'Entrada';
+if (!in_array($currentLeadCategory, $leadCategories, true)) {
+    $currentLeadCategory = 'Entrada';
+}
+
 require_once __DIR__ . '/../../app/views/layouts/header.php';
 ?>
 
@@ -94,8 +100,13 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                     <div>
                         <h2 class="text-2xl font-bold text-gray-900"><?php echo htmlspecialchars($leadNome); ?></h2>
                         <p class="text-sm text-gray-500">Responsável: <span class="font-medium text-indigo-600"><?php echo htmlspecialchars($leadResponsavelNome); ?></span></p>
-                        <?php if (!empty($statusAtual)): ?>
-                            <span class="inline-flex mt-2 items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-800 uppercase tracking-wide"><?php echo htmlspecialchars($statusAtual); ?></span>
+                        <?php if (!empty($statusAtual) || !empty($currentLeadCategory)): ?>
+                            <div class="mt-2 flex flex-wrap gap-2">
+                                <?php if (!empty($statusAtual)): ?>
+                                    <span class="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-800 uppercase tracking-wide"><?php echo htmlspecialchars($statusAtual); ?></span>
+                                <?php endif; ?>
+                                <span class="inline-flex items-center rounded-full bg-gray-200 px-3 py-1 text-xs font-semibold text-gray-700 uppercase tracking-wide">Categoria: <?php echo htmlspecialchars($currentLeadCategory); ?></span>
+                            </div>
                         <?php endif; ?>
                     </div>
 
@@ -151,6 +162,14 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                         <div>
                             <label for="data_reuniao_agendada" class="block text-sm font-medium text-gray-700">Data da Reunião</label>
                             <input type="datetime-local" name="data_reuniao_agendada" id="data_reuniao_agendada" value="<?php echo !empty($prospect['data_reuniao_agendada']) ? htmlspecialchars(formatSaoPauloDate($prospect['data_reuniao_agendada'], 'Y-m-d\TH:i')) : ''; ?>" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+                        </div>
+                        <div>
+                            <label for="lead_category" class="block text-sm font-medium text-gray-700">Categoria do Lead</label>
+                            <select name="lead_category" id="lead_category" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
+                                <?php foreach ($leadCategories as $category): ?>
+                                    <option value="<?php echo htmlspecialchars($category); ?>" <?php echo ($currentLeadCategory === $category) ? 'selected' : ''; ?>><?php echo htmlspecialchars($category); ?></option>
+                                <?php endforeach; ?>
+                            </select>
                         </div>
                         <div class="sm:col-span-1 flex items-center pt-4">
                             <input type="checkbox" name="reuniao_compareceu" id="reuniao_compareceu" value="1" <?php echo (!empty($prospect['reuniao_compareceu'])) ? 'checked' : ''; ?> class="h-4 w-4 text-indigo-600 border-gray-300 rounded">

--- a/crm/prospeccoes/lista.php
+++ b/crm/prospeccoes/lista.php
@@ -173,6 +173,7 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
                 <tr>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Prospecto</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Lead</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Categoria do Lead</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
                     <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Valor</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Responsável</th>
@@ -183,13 +184,14 @@ require_once __DIR__ . '/../../app/views/layouts/header.php';
             <tbody class="bg-white divide-y divide-gray-200">
                 <?php if (empty($prospeccoes)): ?>
                     <tr>
-                        <td colspan="7" class="px-6 py-4 text-center text-gray-500">Nenhuma prospecção encontrada com os filtros aplicados.</td>
+                        <td colspan="8" class="px-6 py-4 text-center text-gray-500">Nenhuma prospecção encontrada com os filtros aplicados.</td>
                     </tr>
                 <?php else: ?>
                     <?php foreach ($prospeccoes as $prospeccao): ?>
                         <tr>
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"><?php echo htmlspecialchars($prospeccao['nome_prospecto']); ?></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600"><?php echo htmlspecialchars($prospeccao['nome_cliente'] ?? 'Lead não vinculado'); ?></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600"><?php echo htmlspecialchars($prospeccao['leadCategory'] ?? 'Entrada'); ?></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                                 <span class="
                                     <?php 

--- a/crm/prospeccoes/salvar.php
+++ b/crm/prospeccoes/salvar.php
@@ -52,13 +52,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     $pdo->beginTransaction();
     try {
-        $sql = "INSERT INTO prospeccoes (cliente_id, nome_prospecto, data_prospeccao, responsavel_id, feedback_inicial, valor_proposto, status) VALUES (:cliente_id, :nome_prospecto, :data_prospeccao, :responsavel_id, :feedback_inicial, :valor_proposto, :status)";
+        $sql = "INSERT INTO prospeccoes (cliente_id, nome_prospecto, data_prospeccao, responsavel_id, feedback_inicial, valor_proposto, status, leadCategory) VALUES (:cliente_id, :nome_prospecto, :data_prospeccao, :responsavel_id, :feedback_inicial, :valor_proposto, :status, :lead_category)";
         $stmt = $pdo->prepare($sql);
         $stmt->execute([
             ':cliente_id' => $cliente_id, ':nome_prospecto' => $nome_prospecto,
             ':data_prospeccao' => $data_prospeccao, ':responsavel_id' => $responsavel_id,
             ':feedback_inicial' => '', ':valor_proposto' => 0,
-            ':status' => 'Cliente ativo'
+            ':status' => 'Cliente ativo', ':lead_category' => 'Entrada'
         ]);
         $prospeccao_id = $pdo->lastInsertId();
 

--- a/database-migrations.md
+++ b/database-migrations.md
@@ -2,6 +2,19 @@
 
 As instruções abaixo atualizam o banco de dados para suportar o fluxo de conversão de leads em serviços pendentes.
 
+## 0. Ajustes na tabela `prospeccoes`
+
+```sql
+ALTER TABLE `prospeccoes`
+  ADD COLUMN `leadCategory` VARCHAR(50) NOT NULL DEFAULT 'Entrada' AFTER `status`;
+
+UPDATE `prospeccoes` p
+LEFT JOIN `clientes` c ON c.`id` = p.`cliente_id`
+   SET p.`leadCategory` = COALESCE(c.`categoria`, 'Entrada')
+ WHERE p.`leadCategory` = 'Entrada';
+```
+
+
 ## 1. Ajustes na tabela `clientes`
 
 ```sql
@@ -109,6 +122,11 @@ UPDATE `processos`
        `orcamento_valor_entrada` = 1500.00,
        `comprovante_pagamento_1` = 'uploads/comprovantes/comprovante_1.pdf'
  WHERE `id` = 42;
+
+-- UPDATE: ajuste da categoria da prospecção conforme evolução do lead
+UPDATE `prospeccoes`
+   SET `leadCategory` = 'Em Negociação'
+ WHERE `id` = 25;
 
 -- DELETE: desativação lógica de serviço mensalista
 UPDATE `cliente_servicos_mensalistas`


### PR DESCRIPTION
## Resumo
- remove o campo de categoria dos formulários de criação, edição e importação de leads e define "Entrada" como padrão
- adiciona o campo de categoria diretamente na prospecção, permitindo atualização pelo detalhe e exibindo a informação na lista
- documenta a migração necessária para criar o novo campo `leadCategory` na tabela de prospecções

## Testes
- `php -l crm/clientes/novo.php`
- `php -l crm/clientes/salvar.php`
- `php -l crm/clientes/editar_cliente.php`
- `php -l crm/clientes/importar.php`
- `php -l crm/clientes/importar_processar.php`
- `php -l crm/prospeccoes/salvar.php`
- `php -l crm/prospeccoes/atualizar.php`
- `php -l crm/prospeccoes/detalhes.php`
- `php -l crm/prospeccoes/lista.php`


------
https://chatgpt.com/codex/tasks/task_e_68e26d5132d08330be87904ae08d27e0