### PR TITLE
Atualiza lista de tradutores e máscara de telefone

### DIFF
--- a/app/views/tradutores/form.php
+++ b/app/views/tradutores/form.php
@@ -68,6 +68,9 @@ function aplicarMascaraTelefone(value) {
 document.addEventListener('DOMContentLoaded', function () {
     const telefoneInput = document.getElementById('telefone');
     if (telefoneInput) {
+        if (telefoneInput.value) {
+            telefoneInput.value = aplicarMascaraTelefone(telefoneInput.value);
+        }
         telefoneInput.addEventListener('input', function (e) {
             e.target.value = aplicarMascaraTelefone(e.target.value);
         });

--- a/app/views/tradutores/lista.php
+++ b/app/views/tradutores/lista.php
@@ -22,7 +22,7 @@ if (isset($_SESSION['success_message'])) {
                     <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome do Tradutor</th>
                     <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
                     <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Telefone</th>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Especialidade</th>
+                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Idioma</th>
                     <th scope="col" class="relative px-6 py-3"><span class="sr-only">Ações</span></th>
                 </tr>
             </thead>


### PR DESCRIPTION
## Summary
- substitui o cabeçalho da coluna por "Idioma" na listagem de tradutores
- aplica a máscara de telefone ao carregar o formulário de tradutores para manter o formato consistente

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2b3122224833087ac5fba39807554