### PR TITLE
Refatora relatório financeiro com segurança e edição inline

### DIFF
--- a/app/controllers/FinanceiroController.php
+++ b/app/controllers/FinanceiroController.php
@@ -1,110 +1,156 @@
 <?php
 /**
  * @file /app/controllers/FinanceiroController.php
- * @description Controller dedicado a gerar relatórios financeiros e
- * fornecer endpoints para interações financeiras, como atualizações inline.
  */
+
 require_once __DIR__ . '/../models/Processo.php';
 
 class FinanceiroController
 {
-    private $pdo;
-    private $processoModel;
+    private PDO $pdo;
+    private Processo $processoModel;
 
-    /**
-     * Construtor da classe.
-     * Inicia o model de Processo, que contém a lógica financeira.
-     *
-     * @param PDO $pdo Uma instância do objeto PDO.
-     */
-    public function __construct($pdo)
+    public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;
         $this->processoModel = new Processo($this->pdo);
     }
 
-    // =======================================================================
-    // AÇÃO PRINCIPAL DE RELATÓRIO
-    // =======================================================================
-
-    /**
-     * Renderiza a página principal do relatório financeiro.
-     * Agrega dados de resumo, a lista detalhada de processos e dados para os filtros.
-     *
-     * @param string $start_date Data de início para os filtros.
-     * @param string $end_date Data de fim para os filtros.
-     * @param string $group_by (Não utilizado neste trecho, mas pode ser para futuros gráficos).
-     */
-    public function index($start_date, $end_date, $group_by)
+    public function index(array $filters): void
     {
-        // 1. Monta o array de filtros para a busca no model
-        $filters = [
-            'data_inicio' => $start_date,
-            'data_fim' => $end_date,
-            'vendedor_id' => $_GET['vendedor_id'] ?? null,
-            'forma_pagamento_id' => $_GET['forma_pagamento_id'] ?? null,
-            'cliente_id' => $_GET['cliente_id'] ?? null, // <<< ADICIONAR 1: Recebe o ID do cliente do filtro.
+        $csrfToken = $this->getCsrfToken();
+
+        if (!empty($_GET) && isset($_GET['csrf_token']) && !$this->isValidCsrfToken($_GET['csrf_token'])) {
+            $_SESSION['error_message'] = 'Sessão expirada. Filtros não aplicados.';
+            $filters['start_date'] = date('Y-m-01');
+            $filters['end_date'] = date('Y-m-t');
+            $filters['group_by'] = 'month';
+            $filters['vendedor_id'] = null;
+            $filters['forma_pagamento_id'] = null;
+            $filters['cliente_id'] = null;
+        }
+
+        $modelFilters = [
+            'data_inicio' => $filters['start_date'] ?? date('Y-m-01'),
+            'data_fim' => $filters['end_date'] ?? date('Y-m-t'),
+            'vendedor_id' => $filters['vendedor_id'] ?? null,
+            'forma_pagamento_id' => $filters['forma_pagamento_id'] ?? null,
+            'cliente_id' => $filters['cliente_id'] ?? null,
         ];
 
-        // 2. Busca os dados principais com base nos filtros
-        // Lista detalhada de processos para a tabela
-        $processos = $this->processoModel->getFinancialData($filters);
-        // Cards com o resumo do período (total, recebido, a receber)
-        // Opcional: Você pode querer que o resumo também considere os filtros.
-        // Se sim, passaria $filters aqui também. Por enquanto, mantive como estava.
-        $overallSummary = $this->processoModel->getOverallFinancialSummary($start_date, $end_date, $filters);
+        $groupBy = $filters['group_by'] ?? 'month';
 
-        // 3. Busca dados para popular os menus de filtro na view
+        $processos = $this->processoModel->getFinancialData($modelFilters);
+        $overallSummary = $this->processoModel->getOverallFinancialSummary($filters['start_date'], $filters['end_date'], $modelFilters);
+        $aggregatedTotals = $this->processoModel->getAggregatedFinancialTotals($filters['start_date'], $filters['end_date'], $modelFilters, $groupBy);
+
         $vendedores = $this->processoModel->getAllVendedores();
         $formas_pagamento = $this->processoModel->getAllFormasPagamento();
-        $clientes = $this->processoModel->getAllClientes(); // <<< ADICIONAR 2: Busca a lista de todos os clientes.
+        $clientes = $this->processoModel->getAllClientes();
+        $statusFinanceiroOptions = $this->processoModel->getStatusFinanceiroOptions();
 
-        // 4. Prepara variáveis para a view
-        $pageTitle = "Relatório Financeiro";
+        $pageTitle = 'Relatório Financeiro';
 
-        // 5. Renderiza a página (agora a variável $clientes estará disponível na view)
         require_once __DIR__ . '/../views/layouts/header.php';
-        require_once __DIR__ . '/../views/financeiro/lista.php'; // Ou o nome que você deu ao seu arquivo de view
+        require_once __DIR__ . '/../views/financeiro/lista.php';
         require_once __DIR__ . '/../views/layouts/footer.php';
     }
 
-    // =======================================================================
-    // ENDPOINT AJAX
-    // =======================================================================
-
-    /**
-     * Endpoint para atualização inline de campos financeiros via AJAX.
-     * Espera uma requisição POST com 'id', 'field' e 'value'.
-     * Retorna uma resposta JSON com o status da operação.
-     */
-    public function updateFinancialField()
+    public function updateFinancialField(): void
     {
         header('Content-Type: application/json');
 
         if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-            http_response_code(405); // Method Not Allowed
-            echo json_encode(['status' => 'error', 'message' => 'Método não permitido.']);
-            exit;
+            $this->respondJson(405, 'Método não permitido.');
         }
 
-        $processId = $_POST['id'] ?? null;
-        $field = $_POST['field'] ?? null;
-        $value = $_POST['value'] ?? null;
-
-        if ($processId && $field && isset($value)) {
-            $success = $this->processoModel->updateProcessFinancialField((int)$processId, $field, $value);
-            
-            if ($success) {
-                echo json_encode(['status' => 'success', 'message' => 'Campo atualizado com sucesso.']);
-            } else {
-                http_response_code(500); // Internal Server Error
-                echo json_encode(['status' => 'error', 'message' => 'Falha ao atualizar o campo no banco de dados.']);
-            }
-        } else {
-            http_response_code(400); // Bad Request
-            echo json_encode(['status' => 'error', 'message' => 'Dados inválidos ou incompletos.']);
+        $token = $_POST['csrf_token'] ?? '';
+        if (!$this->isValidCsrfToken($token)) {
+            $this->respondJson(403, 'Token de segurança inválido ou expirado.');
         }
-        
-        exit; // Termina a execução após a resposta AJAX
+
+        $processId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) ?: null;
+        $field = filter_input(INPUT_POST, 'field', FILTER_SANITIZE_FULL_SPECIAL_CHARS) ?: '';
+        $rawValue = $_POST['value'] ?? null;
+
+        if ($processId === null || $field === '' || $rawValue === null) {
+            $this->respondJson(400, 'Dados inválidos ou incompletos.');
+        }
+
+        $sanitizedValue = null;
+        switch ($field) {
+            case 'valor_total':
+            case 'desconto':
+            case 'valor_recebido':
+            case 'valor_restante':
+                $sanitizedValue = $this->processoModel->parseCurrency((string) $rawValue);
+                break;
+            case 'data_pagamento':
+                $value = trim((string) $rawValue);
+                if ($value === '') {
+                    $sanitizedValue = null;
+                } else {
+                    $date = DateTime::createFromFormat('Y-m-d', $value) ?: DateTime::createFromFormat('d/m/Y', $value);
+                    if (!$date) {
+                        $this->respondJson(400, 'Data informada é inválida.');
+                    }
+                    $sanitizedValue = $date->format('Y-m-d');
+                }
+                break;
+            case 'forma_pagamento_id':
+                $value = filter_var($rawValue, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+                $sanitizedValue = $value ?: null;
+                break;
+            case 'status_financeiro':
+                $value = mb_strtolower(trim((string) $rawValue), 'UTF-8');
+                $allowedStatuses = array_keys($this->processoModel->getStatusFinanceiroOptions());
+                if (!in_array($value, $allowedStatuses, true)) {
+                    $this->respondJson(400, 'Status financeiro inválido.');
+                }
+                $sanitizedValue = $value;
+                break;
+            default:
+                $this->respondJson(400, 'Campo não permitido para atualização.');
+        }
+
+        $success = $this->processoModel->updateProcessFinancialField($processId, $field, $sanitizedValue);
+
+        if (!$success) {
+            $this->respondJson(500, 'Falha ao atualizar o campo no banco de dados.');
+        }
+
+        echo json_encode([
+            'status' => 'success',
+            'message' => 'Campo atualizado com sucesso.',
+        ]);
+        exit;
+    }
+
+    private function getCsrfToken(): string
+    {
+        if (empty($_SESSION['csrf_token'])) {
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+        }
+
+        return $_SESSION['csrf_token'];
+    }
+
+    private function isValidCsrfToken(?string $token): bool
+    {
+        if ($token === null || empty($_SESSION['csrf_token'])) {
+            return false;
+        }
+
+        return hash_equals($_SESSION['csrf_token'], $token);
+    }
+
+    private function respondJson(int $statusCode, string $message): void
+    {
+        http_response_code($statusCode);
+        echo json_encode([
+            'status' => $statusCode >= 200 && $statusCode < 300 ? 'success' : 'error',
+            'message' => $message,
+        ]);
+        exit;
     }
 }

--- a/app/views/financeiro/lista.php
+++ b/app/views/financeiro/lista.php
@@ -1,455 +1,656 @@
 <?php
-// Simulação de dados para que o template funcione (substitua pelo seu carregamento de dados real)
-// require_once __DIR__ . '/../bootstrap.php'; // Exemplo de como você carregaria seus dados
-// $filters = $_GET;
-// $overallSummary = ['total_valor_total' => 50000, 'total_valor_entrada' => 35000, 'total_valor_restante' => 15000, 'media_valor_documento' => 2500];
-// $formas_pagamento = [['id' => 1, 'nome' => 'PIX'], ['id' => 2, 'nome' => 'Boleto'], ['id' => 3, 'nome' => 'Cartão de Crédito']];
-// $vendedores = [['id' => 1, 'nome_vendedor' => 'João Silva'], ['id' => 2, 'nome_vendedor' => 'Maria Oliveira']];
-// $clientes = [['id' => 101, 'nome' => 'Empresa A'], ['id' => 102, 'nome' => 'Cliente B Final']];
-// $aggregatedTotals = ['2025-07' => ['valor_total' => 30000, 'valor_entrada' => 20000, 'valor_restante' => 10000], '2025-06' => ['valor_total' => 20000, 'valor_entrada' => 15000, 'valor_restante' => 5000]];
-// $processos = [
-//     ['id' => 1, 'os_numero_omie' => '12345', 'titulo' => 'Tradução Contrato Social', 'nome_cliente' => 'Empresa A', 'nome_vendedor' => 'João Silva', 'forma_pagamento_id' => 1, 'categorias_servico' => 'Tradução,Apostilamento', 'total_documentos' => 5, 'data_criacao' => '2025-07-15', 'valor_total' => 1500.50, 'orcamento_valor_entrada' => 1000, 'orcamento_valor_restante' => 500.50, 'orcamento_parcelas' => 2, 'data_pagamento_1' => '2025-07-16', 'data_pagamento_2' => '2025-08-16'],
-//     ['id' => 2, 'os_numero_omie' => '12346', 'titulo' => 'Apostilamento de Certidão', 'nome_cliente' => 'Cliente B Final', 'nome_vendedor' => 'Maria Oliveira', 'forma_pagamento_id' => 2, 'categorias_servico' => 'Apostilamento', 'total_documentos' => 2, 'data_criacao' => '2025-07-20', 'valor_total' => 800.00, 'orcamento_valor_entrada' => 800.00, 'orcamento_valor_restante' => 0.00, 'orcamento_parcelas' => 1, 'data_pagamento_1' => '2025-07-21', 'data_pagamento_2' => null],
-// ];
+$processos = $processos ?? [];
+$overallSummary = $overallSummary ?? [
+    'total_valor_total' => 0,
+    'total_valor_entrada' => 0,
+    'total_valor_restante' => 0,
+    'media_valor_documento' => 0,
+];
+$vendedores = $vendedores ?? [];
+$formas_pagamento = $formas_pagamento ?? [];
+$clientes = $clientes ?? [];
+$filters = $filters ?? [];
+$aggregatedTotals = $aggregatedTotals ?? [];
+$statusFinanceiroOptions = $statusFinanceiroOptions ?? [
+    'pendente' => 'Pendente',
+    'parcial' => 'Parcial',
+    'pago' => 'Pago',
+];
+$csrfToken = $csrfToken ?? ($_SESSION['csrf_token'] ?? '');
+$groupBy = $filters['group_by'] ?? 'month';
 
-require_once __DIR__ . '/../layouts/header.php'; 
+$formatCurrency = static function ($value): string {
+    $numeric = is_numeric($value) ? (float) $value : 0.0;
+    return 'R$ ' . number_format($numeric, 2, ',', '.');
+};
+
+$formatDate = static function (?string $date): string {
+    if (empty($date)) {
+        return '—';
+    }
+
+    try {
+        $dateTime = new DateTime($date);
+        return $dateTime->format('d/m/Y');
+    } catch (Throwable $exception) {
+        return '—';
+    }
+};
+
+$formatPeriod = static function (string $period, string $mode): string {
+    if ($period === '') {
+        return '—';
+    }
+
+    switch ($mode) {
+        case 'day':
+            try {
+                return (new DateTime($period))->format('d/m/Y');
+            } catch (Throwable $exception) {
+                return htmlspecialchars($period, ENT_QUOTES, 'UTF-8');
+            }
+        case 'year':
+            return htmlspecialchars($period, ENT_QUOTES, 'UTF-8');
+        default:
+            $parts = explode('-', $period);
+            if (count($parts) === 2) {
+                return sprintf('%02d/%s', (int) $parts[1], $parts[0]);
+            }
+            return htmlspecialchars($period, ENT_QUOTES, 'UTF-8');
+    }
+};
 ?>
 
-<div class="ontainer mx-auto px-4 py-8" id="report-content">
-    <div class="flex justify-between items-center mb-6 print-hide">
-        <h1 class="text-3xl font-bold text-gray-800">Relatório de Serviços</h1>
-
-        <div class="flex space-x-2">
-            <button id="export-csv-btn" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline text-sm">
-                Exportar para CSV
+<div id="financial-report" class="max-w-7xl mx-auto px-4 py-8 space-y-6" data-csrf-token="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between print:hidden">
+        <h1 class="text-3xl font-bold text-gray-800">Relatório Financeiro</h1>
+        <div class="flex flex-wrap gap-2">
+            <button type="button" id="export-csv-btn" aria-label="Exportar tabela para CSV"
+                class="inline-flex items-center gap-2 rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-400">
+                <span class="fas fa-file-csv" aria-hidden="true"></span>
+                Exportar CSV
             </button>
-            <button id="print-btn" class="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline text-sm">
+            <button type="button" id="print-btn" aria-label="Imprimir relatório"
+                class="inline-flex items-center gap-2 rounded-md bg-gray-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400">
+                <span class="fas fa-print" aria-hidden="true"></span>
                 Imprimir
             </button>
         </div>
     </div>
 
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8 print-hide">
-        <div class="bg-white shadow-md rounded-lg p-4 text-center">
-            <h3 class="text-base font-semibold text-gray-600 mb-1">Valor Total Período</h3>
-            <p class="text-2xl font-bold text-blue-600">R$ <?php echo number_format($overallSummary['total_valor_total'] ?? 0, 2, ',', '.'); ?></p>
+    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <div class="rounded-lg bg-white p-4 shadow">
+            <h2 class="text-sm font-medium text-gray-500">Valor total do período</h2>
+            <p class="mt-2 text-2xl font-semibold text-blue-600">
+                <?= htmlspecialchars($formatCurrency($overallSummary['total_valor_total'] ?? 0), ENT_QUOTES, 'UTF-8'); ?>
+            </p>
         </div>
-        <div class="bg-white shadow-md rounded-lg p-4 text-center">
-            <h3 class="text-base font-semibold text-gray-600 mb-1">Entrada Recebida</h3>
-            <p class="text-2xl font-bold text-green-600">R$ <?php echo number_format($overallSummary['total_valor_entrada'] ?? 0, 2, ',', '.'); ?></p>
+        <div class="rounded-lg bg-white p-4 shadow">
+            <h2 class="text-sm font-medium text-gray-500">Valor recebido</h2>
+            <p class="mt-2 text-2xl font-semibold text-emerald-600">
+                <?= htmlspecialchars($formatCurrency($overallSummary['total_valor_entrada'] ?? 0), ENT_QUOTES, 'UTF-8'); ?>
+            </p>
         </div>
-        <div class="bg-white shadow-md rounded-lg p-4 text-center">
-            <h3 class="text-base font-semibold text-gray-600 mb-1">Valor Restante</h3>
-            <p class="text-2xl font-bold text-red-600">R$ <?php echo number_format($overallSummary['total_valor_restante'] ?? 0, 2, ',', '.'); ?></p>
+        <div class="rounded-lg bg-white p-4 shadow">
+            <h2 class="text-sm font-medium text-gray-500">Valor restante</h2>
+            <p class="mt-2 text-2xl font-semibold text-rose-600">
+                <?= htmlspecialchars($formatCurrency($overallSummary['total_valor_restante'] ?? 0), ENT_QUOTES, 'UTF-8'); ?>
+            </p>
         </div>
-        <div class="bg-white shadow-md rounded-lg p-4 text-center">
-            <h3 class="text-base font-semibold text-gray-600 mb-1">Média por Documento (Período)</h3>
-            <p class="text-2xl font-bold text-purple-600">R$ <?php echo number_format($overallSummary['media_valor_documento'] ?? 0, 2, ',', '.'); ?></p>
+        <div class="rounded-lg bg-white p-4 shadow">
+            <h2 class="text-sm font-medium text-gray-500">Média por documento</h2>
+            <p class="mt-2 text-2xl font-semibold text-purple-600">
+                <?= htmlspecialchars($formatCurrency($overallSummary['media_valor_documento'] ?? 0), ENT_QUOTES, 'UTF-8'); ?>
+            </p>
         </div>
     </div>
 
+    <div class="rounded-lg bg-white p-6 shadow print:hidden">
+        <form method="get" action="/financeiro.php" class="grid gap-4 md:grid-cols-2 lg:grid-cols-6">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
 
-    <div class="bg-white shadow-md rounded-lg p-4 mb-6 print-hide">
-        <h2 class="text-xl font-semibold mb-3 text-gray-700">Filtrar Dados Financeiros</h2>
-        <form method="GET" action="/financeiro.php" class="grid grid-cols-1 md:grid-cols-6 gap-3 items-end">
-            <div>
-                <label for="start_date" class="block text-gray-700 text-sm font-bold mb-1">Data Inicial (Criação):</label>
-                <input type="date" name="start_date" id="start_date"
-                       value="<?php echo htmlspecialchars($_GET['start_date'] ?? date('Y-m-01')); ?>"
-                       class="shadow appearance-none border rounded w-full py-1 px-2 text-sm text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
-            </div>
-            <div>
-                <label for="end_date" class="block text-gray-700 text-sm font-bold mb-1">Data Final (Criação):</label>
-                <input type="date" name="end_date" id="end_date"
-                       value="<?php echo htmlspecialchars($_GET['end_date'] ?? date('Y-m-t')); ?>"
-                       class="shadow appearance-none border rounded w-full py-1 px-2 text-sm text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
-            </div>
+            <label class="flex flex-col gap-1 text-sm font-semibold text-gray-700">
+                Data inicial
+                <input type="date" name="start_date" id="start_date" value="<?= htmlspecialchars($filters['start_date'] ?? date('Y-m-01'), ENT_QUOTES, 'UTF-8'); ?>"
+                    class="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+            </label>
 
-            <div>
-                <label for="cliente_id" class="block text-gray-700 text-sm font-bold mb-1">Cliente:</label>
-                <select name="cliente_id" id="cliente_id"
-                        class="shadow appearance-none border rounded w-full py-1 px-2 text-sm text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
-                    <option value="">Todos os Clientes</option>
+            <label class="flex flex-col gap-1 text-sm font-semibold text-gray-700">
+                Data final
+                <input type="date" name="end_date" id="end_date" value="<?= htmlspecialchars($filters['end_date'] ?? date('Y-m-t'), ENT_QUOTES, 'UTF-8'); ?>"
+                    class="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+            </label>
+
+            <label class="flex flex-col gap-1 text-sm font-semibold text-gray-700">
+                Agrupar por
+                <select name="group_by" id="group_by"
+                    class="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
                     <?php
-                    // IMPORTANTE: Você precisará passar a variável $clientes do seu controller para cá.
-                    if (!empty($clientes)):
-                        foreach ($clientes as $cliente): ?>
-                            <option value="<?php echo htmlspecialchars($cliente['id']); ?>"
-                                <?php echo ((string)($filters['cliente_id'] ?? '') === (string)$cliente['id']) ? 'selected' : ''; ?>>
-                                <?php echo htmlspecialchars($cliente['nome']); ?>
-                            </option>
-                        <?php endforeach;
-                    endif;
-                    ?>
+                    $groupOptions = [
+                        'day' => 'Dia',
+                        'month' => 'Mês',
+                        'year' => 'Ano',
+                    ];
+                    foreach ($groupOptions as $value => $label):
+                        $selected = ($groupBy === $value) ? 'selected' : '';
+                        ?>
+                        <option value="<?= htmlspecialchars($value, ENT_QUOTES, 'UTF-8'); ?>" <?= $selected; ?>>
+                            <?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?>
+                        </option>
+                    <?php endforeach; ?>
                 </select>
-            </div>
+            </label>
 
-            <div>
-                <label for="forma_pagamento_id" class="block text-gray-700 text-sm font-bold mb-1">Forma Pagto:</label>
+            <label class="flex flex-col gap-1 text-sm font-semibold text-gray-700">
+                Cliente
+                <select name="cliente_id" id="cliente_id"
+                    class="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+                    <option value="">Todos</option>
+                    <?php foreach ($clientes as $cliente): ?>
+                        <option value="<?= htmlspecialchars((string) ($cliente['id'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
+                            <?= ((string) ($filters['cliente_id'] ?? '') === (string) ($cliente['id'] ?? '')) ? 'selected' : ''; ?>>
+                            <?= htmlspecialchars($cliente['nome'] ?? $cliente['nome_cliente'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+
+            <label class="flex flex-col gap-1 text-sm font-semibold text-gray-700">
+                Forma de pagamento
                 <select name="forma_pagamento_id" id="forma_pagamento_id"
-                        class="shadow appearance-none border rounded w-full py-1 px-2 text-sm text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
-                    <option value="todos">Todas</option>
-                    <?php if (!empty($formas_pagamento)) : foreach ($formas_pagamento as $forma): ?>
-                        <option value="<?php echo htmlspecialchars($forma['id']); ?>"
-                            <?php echo ((string)($filters['forma_pagamento_id'] ?? '') === (string)$forma['id']) ? 'selected' : ''; ?>>
-                            <?php echo htmlspecialchars($forma['nome']); ?>
+                    class="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+                    <option value="">Todas</option>
+                    <?php foreach ($formas_pagamento as $forma): ?>
+                        <option value="<?= htmlspecialchars((string) ($forma['id'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
+                            <?= ((string) ($filters['forma_pagamento_id'] ?? '') === (string) ($forma['id'] ?? '')) ? 'selected' : ''; ?>>
+                            <?= htmlspecialchars($forma['nome'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
                         </option>
-                    <?php endforeach; endif; ?>
+                    <?php endforeach; ?>
                 </select>
-            </div>
-            <div>
-                <label for="vendedor_id" class="block text-gray-700 text-sm font-bold mb-1">Vendedor:</label>
+            </label>
+
+            <label class="flex flex-col gap-1 text-sm font-semibold text-gray-700">
+                Vendedor
                 <select name="vendedor_id" id="vendedor_id"
-                        class="shadow appearance-none border rounded w-full py-1 px-2 text-sm text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
-                    <option value="">Todos Vendedores</option>
-                    <?php if (!empty($vendedores)) : foreach ($vendedores as $vendedor): ?>
-                        <option value="<?php echo htmlspecialchars($vendedor['id']); ?>"
-                            <?php echo ((string)($filters['vendedor_id'] ?? '') === (string)$vendedor['id']) ? 'selected' : ''; ?>>
-                            <?php echo htmlspecialchars($vendedor['nome_vendedor']); ?>
+                    class="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+                    <option value="">Todos</option>
+                    <?php foreach ($vendedores as $vendedor): ?>
+                        <option value="<?= htmlspecialchars((string) ($vendedor['id'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
+                            <?= ((string) ($filters['vendedor_id'] ?? '') === (string) ($vendedor['id'] ?? '')) ? 'selected' : ''; ?>>
+                            <?= htmlspecialchars($vendedor['nome_vendedor'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
                         </option>
-                    <?php endforeach; endif; ?>
+                    <?php endforeach; ?>
                 </select>
-            </div>
-            <div>
-                <button type="submit"
-                        class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline text-sm w-full">
-                    Aplicar Filtro
+            </label>
+
+            <div class="flex items-end">
+                <button type="submit" class="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400">
+                    Aplicar filtros
                 </button>
             </div>
         </form>
     </div>
 
     <?php if (!empty($aggregatedTotals)): ?>
-        <div class="bg-white shadow-md rounded-lg p-4 mb-6">
-            <h2 class="text-xl font-semibold mb-3 text-gray-700">Totais de Processos Finalizados (Por Mês)</h2>
-            <div class="overflow-x-auto">
-                <table class="min-w-full bg-white">
-                    <thead class="bg-gray-200 text-gray-600 uppercase text-xs leading-normal">
+        <div class="space-y-3">
+            <h2 class="text-lg font-semibold text-gray-700">Totais agregados por período</h2>
+            <div class="overflow-x-auto rounded-lg bg-white shadow">
+                <table class="min-w-full divide-y divide-gray-200 text-sm">
+                    <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-600">
                         <tr>
-                            <th class="py-2 px-2 text-left">Período</th>
-                            <th class="py-2 px-2 text-right">Valor Total</th>
-                            <th class="py-2 px-2 text-right">Valor Entrada</th>
-                            <th class="py-2 px-2 text-right">Valor Restante</th>
+                            <th class="px-4 py-3 text-left">Período</th>
+                            <th class="px-4 py-3 text-right">Processos</th>
+                            <th class="px-4 py-3 text-right">Valor total</th>
+                            <th class="px-4 py-3 text-right">Valor recebido</th>
+                            <th class="px-4 py-3 text-right">Valor restante</th>
                         </tr>
                     </thead>
-                    <tbody class="text-gray-600 text-xs font-light">
-                        <?php foreach ($aggregatedTotals as $period => $totals): ?>
-                            <tr class="border-b border-gray-200 hover:bg-gray-100">
-                                <td class="py-2 px-2 text-left whitespace-no-wrap"><?php echo htmlspecialchars($period); ?></td>
-                                <td class="py-2 px-2 text-right">R$ <?php echo number_format($totals['valor_total'], 2, ',', '.'); ?></td>
-                                <td class="py-2 px-2 text-right">R$ <?php echo number_format($totals['valor_entrada'], 2, ',', '.'); ?></td>
-                                <td class="py-2 px-2 text-right">R$ <?php echo number_format($totals['valor_restante'], 2, ',', '.'); ?></td>
+                    <tbody class="divide-y divide-gray-100 bg-white text-gray-700">
+                        <?php foreach ($aggregatedTotals as $row): ?>
+                            <tr>
+                                <td class="px-4 py-3 font-medium">
+                                    <?= $formatPeriod((string) ($row['period'] ?? ''), $groupBy); ?>
+                                </td>
+                                <td class="px-4 py-3 text-right">
+                                    <?= htmlspecialchars((string) ($row['process_count'] ?? 0), ENT_QUOTES, 'UTF-8'); ?>
+                                </td>
+                                <td class="px-4 py-3 text-right">
+                                    <?= htmlspecialchars($formatCurrency($row['total_valor_total'] ?? 0), ENT_QUOTES, 'UTF-8'); ?>
+                                </td>
+                                <td class="px-4 py-3 text-right">
+                                    <?= htmlspecialchars($formatCurrency($row['total_valor_recebido'] ?? $row['total_valor_entrada'] ?? 0), ENT_QUOTES, 'UTF-8'); ?>
+                                </td>
+                                <td class="px-4 py-3 text-right">
+                                    <?= htmlspecialchars($formatCurrency($row['total_valor_restante'] ?? 0), ENT_QUOTES, 'UTF-8'); ?>
+                                </td>
                             </tr>
                         <?php endforeach; ?>
                     </tbody>
                 </table>
             </div>
         </div>
-    <?php else: ?>
-        <p class="text-gray-600 mb-6 text-xs print-hide">Nenhum total agregado de processos finalizados encontrado para o período selecionado.</p>
     <?php endif; ?>
 
-    <h2 class="text-xl font-semibold mb-3 text-gray-700">Processos Individuais</h2>
-    <div class="bg-white shadow-md rounded-lg overflow-x-auto">
-        <table id="processos-table" class="min-w-full leading-normal">
-            <thead>
-                <tr>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-left text-[9px] font-semibold text-gray-600 uppercase tracking-wider">OS</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-left text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-title">Título</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-left text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-client">Cliente</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-left text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-seller">Vendedor</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-left text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-pay-form">Forma Pagto</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-left text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-service-type">Tipo Serviço</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-center text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-docs">Nº Docs</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-center text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-date">Data Criação</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-right text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-value">Total</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-right text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-value">Entrada</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-right text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-value">Restante</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-center text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-tiny">Parcelas</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-center text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-date">Data 1ª Parcela</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-center text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-date">Data 2ª Parcela</th>
-                    <th class="px-1 py-1 border-b-2 border-gray-400 bg-gray-100 text-center text-[9px] font-semibold text-gray-600 uppercase tracking-wider table-col-status">Status Pagto</th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php if (empty($processos)): ?>
+    <div class="rounded-lg bg-white shadow">
+        <div class="overflow-x-auto">
+            <table id="processos-table" class="min-w-full divide-y divide-gray-200 text-sm">
+                <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-600">
                     <tr>
-                        <td colspan="15" class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-center"> Nenhum processo para exibir para o período ou filtros selecionados.
-                        </td>
+                        <th class="px-3 py-3 text-left">ID</th>
+                        <th class="px-3 py-3 text-left">Cliente</th>
+                        <th class="px-3 py-3 text-left">Serviço</th>
+                        <th class="px-3 py-3 text-left">Vendedor</th>
+                        <th class="px-3 py-3 text-left">Forma de pagamento</th>
+                        <th class="px-3 py-3 text-right">Valor total</th>
+                        <th class="px-3 py-3 text-right">Desconto</th>
+                        <th class="px-3 py-3 text-right">Valor recebido</th>
+                        <th class="px-3 py-3 text-right">Valor restante</th>
+                        <th class="px-3 py-3 text-left">Status financeiro</th>
+                        <th class="px-3 py-3 text-left">Data pagamento</th>
+                        <th class="px-3 py-3 text-left">Data criação</th>
                     </tr>
-                <?php else: ?>
-                    <?php foreach ($processos as $processo): ?>
-                        <tr data-process-id="<?php echo htmlspecialchars($processo['id']); ?>">
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs">
-                                <span class="text-blue-600 hover:text-blue-900 whitespace-no-wrap">
-                                    <?php echo htmlspecialchars(empty($processo['os_numero_omie']) ? 'Aguardando Omie' : $processo['os_numero_omie']); ?>
-                                </span>
-                            </td>
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-truncate">
-                                <p class="text-gray-900" title="<?php echo htmlspecialchars($processo['titulo'] ?? ''); ?>"><?php echo htmlspecialchars($processo['titulo'] ?? ''); ?></p>
-                            </td>
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-truncate">
-                                <p class="text-gray-900" title="<?php echo htmlspecialchars($processo['nome_cliente'] ?? ''); ?>"><?php echo htmlspecialchars($processo['nome_cliente'] ?? ''); ?></p>
-                            </td>
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-truncate">
-                                <p class="text-gray-900" title="<?php echo htmlspecialchars($processo['nome_vendedor'] ?? ''); ?>"><?php echo htmlspecialchars($processo['nome_vendedor'] ?? ''); ?></p>
-                            </td>
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs">
-                                <select name="forma_pagamento_id"
-                                        class="editable-select shadow-sm border rounded w-full py-1 px-2 text-xs text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-                                        data-process-id="<?php echo $processo['id']; ?>"
-                                        data-field="forma_pagamento_id">
-                                    <option value="">Selecione...</option>
-                                    <?php if (!empty($formas_pagamento)) : foreach ($formas_pagamento as $forma): ?>
-                                        <option value="<?php echo htmlspecialchars($forma['id']); ?>"
-                                            <?php if (isset($processo['forma_pagamento_id']) && $processo['forma_pagamento_id'] == $forma['id']) echo 'selected'; ?>>
-                                            <?php echo htmlspecialchars($forma['nome']); ?>
-                                        </option>
-                                    <?php endforeach; endif; ?>
-                                </select>
-                            </td>
-
-                            <td class="px-2 py-2 border-b border-gray-200 bg-white text-xs text-truncate">
-                                <?php
-                                    $servicos_originais = $processo['categorias_servico'] ?? '';
-                                    if (!empty($servicos_originais)) {
-                                        $mapa_abreviacoes = ['Tradução' => 'trad.', 'CRC' => 'crc', 'Apostilamento' => 'apost.', 'Postagem' => 'post.'];
-                                        $servicos_array = explode(',', $servicos_originais);
-                                        $servicos_abreviados_array = [];
-                                        foreach ($servicos_array as $servico) {
-                                            $servico_limpo = trim($servico);
-                                            $servicos_abreviados_array[] = $mapa_abreviacoes[$servico_limpo] ?? $servico_limpo;
-                                        }
-                                        $texto_abreviado = implode(', ', $servicos_abreviados_array);
-                                    } else {
-                                        $texto_abreviado = 'N/A';
-                                    }
-                                ?>
-                                <p class="text-gray-900" title="<?php echo htmlspecialchars($servicos_originais); ?>">
-                                    <?php echo htmlspecialchars($texto_abreviado); ?>
-                                </p>
-                            </td>
-
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-center">
-                                <p class="text-gray-900 whitespace-no-wrap"><?php echo htmlspecialchars($processo['total_documentos'] ?? 0); ?></p>
-                            </td>
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-center">
-                                <p class="text-gray-900 whitespace-no-wrap">
-                                    <?php echo $processo['data_criacao'] ? date('d/m/Y', strtotime($processo['data_criacao'])) : 'N/A'; ?>
-                                </p>
-                            </td>
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-right editable" data-field="valor_total" data-value-type="currency">
-                                <span class="editable-content">R$ <?php echo number_format($processo['valor_total'] ?? 0, 2, ',', '.'); ?></span>
-                                <input type="text" class="edit-input hidden w-full text-right" value="<?php echo number_format($processo['valor_total'] ?? 0, 2, ',', '.'); ?>">
-                            </td>
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-right editable" data-field="orcamento_valor_entrada" data-value-type="currency">
-                                <span class="editable-content">R$ <?php echo number_format($processo['orcamento_valor_entrada'] ?? 0, 2, ',', '.'); ?></span>
-                                <input type="text" class="edit-input hidden w-full text-right" value="<?php echo number_format($processo['orcamento_valor_entrada'] ?? 0, 2, ',', '.'); ?>">
-                            </td>
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-right editable" data-field="orcamento_valor_restante" data-value-type="currency">
-                                <span class="editable-content">R$ <?php echo number_format($processo['orcamento_valor_restante'] ?? 0, 2, ',', '.'); ?></span>
-                                <input type="text" class="edit-input hidden w-full text-right" value="<?php echo number_format($processo['orcamento_valor_restante'] ?? 0, 2, ',', '.'); ?>">
-                            </td>
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-center">
-                                <p class="text-gray-900 whitespace-no-wrap"><?php echo htmlspecialchars($processo['orcamento_parcelas'] ?? 'N/A'); ?></p>
-                            </td>
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-center editable" data-field="data_pagamento_1" data-value-type="date">
-                                <span class="editable-content"><?php echo $processo['data_pagamento_1'] ? date('d/m/Y', strtotime($processo['data_pagamento_1'])) : 'N/A'; ?></span>
-                                <input type="date" class="edit-input hidden w-full text-center" value="<?php echo $processo['data_pagamento_1'] ?? ''; ?>">
-                            </td>
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-center editable" data-field="data_pagamento_2" data-value-type="date">
-                                <span class="editable-content"><?php echo $processo['data_pagamento_2'] ? date('d/m/Y', strtotime($processo['data_pagamento_2'])) : 'N/A'; ?></span>
-                                <input type="date" class="edit-input hidden w-full text-center" value="<?php echo $processo['data_pagamento_2'] ?? ''; ?>">
-                            </td>
-                            <td class="px-1 py-1 border-b border-gray-200 bg-white text-xs text-center">
-                                <?php
-                                    $status_pagamento_class = 'bg-red-200 text-red-900';
-                                    $status_pagamento_text = 'Pendente';
-                                    if (($processo['valor_total'] ?? 0) > 0 && ($processo['orcamento_valor_restante'] ?? 0) <= 0.01) {
-                                        $status_pagamento_class = 'bg-green-200 text-green-900';
-                                        $status_pagamento_text = 'Pago';
-                                    } elseif (($processo['orcamento_valor_entrada'] ?? 0) > 0 && ($processo['orcamento_valor_restante'] ?? 0) > 0) {
-                                        $status_pagamento_class = 'bg-yellow-200 text-yellow-900';
-                                        $status_pagamento_text = 'Parcial';
-                                    }
-                                ?>
-                                <span class="relative inline-block px-2 py-0.5 font-semibold <?php echo $status_pagamento_class; ?> leading-tight rounded-full text-xs">
-                                    <span class="relative"><?php echo $status_pagamento_text; ?></span>
-                                </span>
-                            </td>
+                </thead>
+                <tbody class="divide-y divide-gray-100 bg-white text-gray-700">
+                    <?php if (empty($processos)): ?>
+                        <tr>
+                            <td colspan="12" class="px-4 py-6 text-center text-sm text-gray-500">Nenhum processo encontrado para os filtros selecionados.</td>
                         </tr>
-                    <?php endforeach; ?>
-                <?php endif; ?>
-            </tbody>
-        </table>
+                    <?php else: ?>
+                        <?php foreach ($processos as $processo):
+                            $processId = (int) ($processo['id'] ?? 0);
+                            $valorTotal = $formatCurrency($processo['valor_total'] ?? 0);
+                            $desconto = $formatCurrency($processo['desconto'] ?? 0);
+                            $valorRecebido = $formatCurrency($processo['valor_recebido'] ?? 0);
+                            $valorRestante = $formatCurrency($processo['valor_restante'] ?? 0);
+                            $rawPaymentDate = $processo['data_pagamento'] ?? null;
+                            $statusFinanceiro = strtolower((string) ($processo['status_financeiro'] ?? 'pendente'));
+                            ?>
+                            <tr data-process-id="<?= htmlspecialchars((string) $processId, ENT_QUOTES, 'UTF-8'); ?>">
+                                <td class="px-3 py-3 font-medium text-gray-900">
+                                    <?= htmlspecialchars((string) $processId, ENT_QUOTES, 'UTF-8'); ?>
+                                </td>
+                                <td class="px-3 py-3">
+                                    <?= htmlspecialchars($processo['cliente_nome'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                                </td>
+                                <td class="px-3 py-3">
+                                    <?= htmlspecialchars($processo['titulo'] ?? $processo['categorias_servico'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                                </td>
+                                <td class="px-3 py-3">
+                                    <?= htmlspecialchars($processo['nome_vendedor'] ?? '—', ENT_QUOTES, 'UTF-8'); ?>
+                                </td>
+                                <td class="px-3 py-3">
+                                    <select class="editable-select w-full rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                        data-field="forma_pagamento_id" data-id="<?= htmlspecialchars((string) $processId, ENT_QUOTES, 'UTF-8'); ?>" aria-label="Selecionar forma de pagamento">
+                                        <option value="">Não informado</option>
+                                        <?php foreach ($formas_pagamento as $forma):
+                                            $formaId = (string) ($forma['id'] ?? '');
+                                            $selected = ((string) ($processo['forma_pagamento_id'] ?? '') === $formaId) ? 'selected' : '';
+                                            ?>
+                                            <option value="<?= htmlspecialchars($formaId, ENT_QUOTES, 'UTF-8'); ?>" <?= $selected; ?>>
+                                                <?= htmlspecialchars($forma['nome'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </td>
+                                <td class="px-3 py-3 text-right">
+                                    <span class="editable-content inline-flex min-w-[6rem] justify-end rounded px-2 py-1 text-sm" contenteditable="true"
+                                        data-field="valor_total" data-id="<?= htmlspecialchars((string) $processId, ENT_QUOTES, 'UTF-8'); ?>" data-value-type="currency"
+                                        data-original-value="<?= htmlspecialchars($valorTotal, ENT_QUOTES, 'UTF-8'); ?>">
+                                        <?= htmlspecialchars($valorTotal, ENT_QUOTES, 'UTF-8'); ?>
+                                    </span>
+                                </td>
+                                <td class="px-3 py-3 text-right">
+                                    <span class="editable-content inline-flex min-w-[6rem] justify-end rounded px-2 py-1 text-sm" contenteditable="true"
+                                        data-field="desconto" data-id="<?= htmlspecialchars((string) $processId, ENT_QUOTES, 'UTF-8'); ?>" data-value-type="currency"
+                                        data-original-value="<?= htmlspecialchars($desconto, ENT_QUOTES, 'UTF-8'); ?>">
+                                        <?= htmlspecialchars($desconto, ENT_QUOTES, 'UTF-8'); ?>
+                                    </span>
+                                </td>
+                                <td class="px-3 py-3 text-right">
+                                    <span class="editable-content inline-flex min-w-[6rem] justify-end rounded px-2 py-1 text-sm" contenteditable="true"
+                                        data-field="valor_recebido" data-id="<?= htmlspecialchars((string) $processId, ENT_QUOTES, 'UTF-8'); ?>" data-value-type="currency"
+                                        data-original-value="<?= htmlspecialchars($valorRecebido, ENT_QUOTES, 'UTF-8'); ?>">
+                                        <?= htmlspecialchars($valorRecebido, ENT_QUOTES, 'UTF-8'); ?>
+                                    </span>
+                                </td>
+                                <td class="px-3 py-3 text-right">
+                                    <span class="editable-content inline-flex min-w-[6rem] justify-end rounded px-2 py-1 text-sm" contenteditable="true"
+                                        data-field="valor_restante" data-id="<?= htmlspecialchars((string) $processId, ENT_QUOTES, 'UTF-8'); ?>" data-value-type="currency"
+                                        data-original-value="<?= htmlspecialchars($valorRestante, ENT_QUOTES, 'UTF-8'); ?>">
+                                        <?= htmlspecialchars($valorRestante, ENT_QUOTES, 'UTF-8'); ?>
+                                    </span>
+                                </td>
+                                <td class="px-3 py-3">
+                                    <select class="editable-select w-full rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                        data-field="status_financeiro" data-id="<?= htmlspecialchars((string) $processId, ENT_QUOTES, 'UTF-8'); ?>" aria-label="Selecionar status financeiro">
+                                        <?php foreach ($statusFinanceiroOptions as $value => $label):
+                                            $isSelected = ($statusFinanceiro === strtolower((string) $value));
+                                            ?>
+                                            <option value="<?= htmlspecialchars(strtolower((string) $value), ENT_QUOTES, 'UTF-8'); ?>" <?= $isSelected ? 'selected' : ''; ?>>
+                                                <?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </td>
+                                <td class="px-3 py-3">
+                                    <?php $displayDate = $formatDate($rawPaymentDate); ?>
+                                    <span class="editable-content inline-flex min-w-[6rem] rounded px-2 py-1 text-sm" contenteditable="true"
+                                        data-field="data_pagamento" data-id="<?= htmlspecialchars((string) $processId, ENT_QUOTES, 'UTF-8'); ?>" data-value-type="date"
+                                        data-original-value="<?= htmlspecialchars($displayDate, ENT_QUOTES, 'UTF-8'); ?>"
+                                        data-raw-value="<?= htmlspecialchars((string) $rawPaymentDate, ENT_QUOTES, 'UTF-8'); ?>">
+                                        <?= htmlspecialchars($displayDate, ENT_QUOTES, 'UTF-8'); ?>
+                                    </span>
+                                </td>
+                                <td class="px-3 py-3">
+                                    <?= htmlspecialchars($formatDate($processo['data_criacao'] ?? null), ENT_QUOTES, 'UTF-8'); ?>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
     </div>
+
+    <div id="finance-feedback" class="print:hidden" aria-live="polite"></div>
 </div>
 
 <style>
-/* Estilos visuais gerais */
-.table-col-title, .table-col-client, .table-col-seller, .table-col-pay-form, .table-col-service-type {
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.table-col-title { max-width: 150px; } .table-col-client { max-width: 120px; } .table-col-seller { max-width: 80px; } .table-col-pay-form { max-width: 80px; } .table-col-service-type { max-width: 100px; } .table-col-docs { max-width: 60px; } .table-col-date { max-width: 90px; } .table-col-value { max-width: 100px; } .table-col-tiny { max-width: 60px; } .table-col-status { max-width: 80px; }
-.editable input.edit-input { border: 1px solid #ccc; padding: 2px 3px; box-shadow: inset 0 1px 2px rgba(0,0,0,0.1); border-radius: 4px; font-size: 0.75rem; line-height: 1rem; box-sizing: border-box; }
-.editable input[type="date"].edit-input { min-width: 100px; }
-.editable.saving { background-color: #e0f2fe; } .editable.error { background-color: #ffebee; } .editable.success { background-color: #e8f5e9; }
-.editable .editable-content.hidden + .edit-input { display: block; } .editable .editable-content { display: inline-block; } .editable .edit-input { display: none; }
-</style>
-
-<style>
-@media print {
-    /* Define o layout da página de impressão como paisagem para acomodar a tabela */
-    @page {
-        size: A4 landscape;
-        margin: 1.5cm;
+    #financial-report .editable-content:focus {
+        outline: 2px solid rgba(59, 130, 246, 0.6);
+        outline-offset: 2px;
     }
-
-    body, #report-content {
-        background-color: #fff !important;
-        color: #000 !important;
-        width: 100% !important;
-        margin: 0 !important;
-        padding: 0 !important;
-        box-shadow: none !important;
+    #financial-report .editable-content[contenteditable="true"] {
+        cursor: text;
+        min-height: 1.75rem;
     }
-    
-    /* Esconde elementos desnecessários na impressão */
-    .print-hide, 
-    header, /* Esconde o header principal do site (ajuste o seletor se for diferente) */
-    footer, /* Esconde o footer principal do site (ajuste o seletor se for diferente) */
-    .editable-select,
-    .editable input
-    {
-        display: none !important;
-    }
-
-    /* Garante que os containers do relatório fiquem visíveis e bem formatados */
-    .bg-white, .overflow-x-auto, #report-content {
-        box-shadow: none !important;
-        border: none !important;
-        overflow: visible !important;
-    }
-    
-    /* Ajusta a tabela para a impressão */
-    table {
-        width: 100%;
-        font-size: 8pt; /* Reduz a fonte para caber mais colunas */
-        border-collapse: collapse;
-    }
-
-    th, td {
-        border: 1px solid #ccc; /* Adiciona borda para melhor visualização */
-        padding: 4px;
-        white-space: normal;
-        word-wrap: break-word;
-    }
-
-    th {
-        background-color: #f2f2f2 !important;
-    }
-    
-    /* Força o navegador a imprimir as cores de fundo dos status */
-    .bg-red-200, .bg-green-200, .bg-yellow-200 {
-        print-color-adjust: exact;
-        -webkit-print-color-adjust: exact;
-    }
-    
-    a {
-        text-decoration: none;
-        color: inherit;
-    }
-}
 </style>
 
 <script>
-document.addEventListener('DOMContentLoaded', function () {
+(function () {
+    const container = document.getElementById('financial-report');
+    if (!container) {
+        return;
+    }
+
+    const csrfToken = container.dataset.csrfToken || '';
+    const feedback = document.getElementById('finance-feedback');
+
+    const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+        style: 'currency',
+        currency: 'BRL',
+        minimumFractionDigits: 2,
+    });
+
+    function showFeedback(message, type = 'success') {
+        if (!feedback) {
+            return;
+        }
+
+        feedback.textContent = message;
+        feedback.className = type === 'success'
+            ? 'mt-2 rounded-md bg-emerald-100 px-3 py-2 text-sm font-medium text-emerald-800'
+            : 'mt-2 rounded-md bg-rose-100 px-3 py-2 text-sm font-medium text-rose-800';
+
+        setTimeout(() => {
+            feedback.textContent = '';
+            feedback.className = '';
+        }, 4000);
+    }
+
+    function parseValue(type, value, element) {
+        const trimmed = value.trim();
+
+        if (trimmed === '') {
+            return null;
+        }
+
+        if (type === 'currency') {
+            const normalized = trimmed
+                .replace(/[^0-9,.-]/g, '')
+                .replace(/\.(?=\d{3})/g, '')
+                .replace(',', '.');
+            const numericValue = Number.parseFloat(normalized);
+            if (Number.isNaN(numericValue)) {
+                throw new Error('Valor monetário inválido.');
+            }
+            return numericValue.toFixed(2);
+        }
+
+        if (type === 'date') {
+            const isoPattern = /^\d{4}-\d{2}-\d{2}$/;
+            const brPattern = /^\d{2}\/\d{2}\/\d{4}$/;
+
+            if (isoPattern.test(trimmed)) {
+                return trimmed;
+            }
+
+            if (brPattern.test(trimmed)) {
+                const [day, month, year] = trimmed.split('/');
+                return `${year}-${month}-${day}`;
+            }
+
+            throw new Error('Data em formato inválido.');
+        }
+
+        return trimmed;
+    }
+
+    function formatValueForDisplay(type, value) {
+        if (value === null || value === '') {
+            return '—';
+        }
+
+        if (type === 'currency') {
+            return currencyFormatter.format(Number.parseFloat(value));
+        }
+
+        if (type === 'date') {
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) {
+                return '—';
+            }
+            const day = String(date.getDate()).padStart(2, '0');
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const year = date.getFullYear();
+            return `${day}/${month}/${year}`;
+        }
+
+        return value;
+    }
+
+    function handleEditableBlur(event) {
+        const target = event.currentTarget;
+        const original = target.dataset.originalValue ?? '';
+        const valueType = target.dataset.valueType || 'text';
+        const processId = target.dataset.id;
+        const field = target.dataset.field;
+
+        if (!processId || !field) {
+            return;
+        }
+
+        const currentValue = target.textContent.trim();
+        if (currentValue === original.trim()) {
+            target.textContent = original;
+            return;
+        }
+
+        let payloadValue;
+        try {
+            payloadValue = parseValue(valueType, target.textContent, target);
+        } catch (error) {
+            showFeedback(error.message, 'error');
+            target.textContent = original;
+            return;
+        }
+
+        submitUpdate(processId, field, payloadValue, target, valueType);
+    }
+
+    function handleEditableKeyDown(event) {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            event.currentTarget.blur();
+        }
+    }
+
+    function submitUpdate(id, field, value, element, valueType) {
+        element.classList.add('bg-blue-50');
+
+        const formData = new URLSearchParams();
+        formData.append('id', id);
+        formData.append('field', field);
+        formData.append('value', value === null ? '' : value);
+        formData.append('csrf_token', csrfToken);
+
+        fetch('/financeiro.php?action=update_field', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: formData.toString(),
+            credentials: 'same-origin',
+        })
+            .then(async (response) => {
+                const data = await response.json().catch(() => ({ status: 'error', message: 'Erro desconhecido.' }));
+                if (!response.ok || data.status !== 'success') {
+                    throw new Error(data.message || 'Falha ao atualizar.');
+                }
+
+                if (value === null || value === '') {
+                    element.textContent = '—';
+                    element.dataset.originalValue = '—';
+                    if (valueType === 'date') {
+                        element.dataset.rawValue = '';
+                    }
+                } else {
+                    const displayValue = formatValueForDisplay(valueType, value);
+                    element.textContent = displayValue;
+                    element.dataset.originalValue = displayValue;
+                    if (valueType === 'date') {
+                        element.dataset.rawValue = value;
+                    }
+                }
+
+                element.classList.remove('bg-blue-50');
+                element.classList.add('bg-emerald-50');
+                setTimeout(() => element.classList.remove('bg-emerald-50'), 1200);
+                if (element.tagName === 'SELECT') {
+                    element.dataset.originalValue = element.value;
+                }
+                showFeedback('Campo atualizado com sucesso.');
+            })
+            .catch((error) => {
+                element.classList.remove('bg-blue-50');
+                element.classList.add('bg-rose-50');
+                setTimeout(() => element.classList.remove('bg-rose-50'), 1200);
+                showFeedback(error.message || 'Erro ao atualizar campo.', 'error');
+                element.textContent = element.dataset.originalValue ?? '—';
+            });
+    }
+
+    function wireEditableElements() {
+        const editableElements = container.querySelectorAll('.editable-content');
+        editableElements.forEach((element) => {
+            element.addEventListener('blur', handleEditableBlur);
+            element.addEventListener('keydown', handleEditableKeyDown);
+            element.addEventListener('focus', () => {
+                element.dataset.originalValue = element.textContent.trim();
+            });
+        });
+
+        const selectElements = container.querySelectorAll('.editable-select');
+        selectElements.forEach((select) => {
+            select.addEventListener('focus', () => {
+                select.dataset.originalValue = select.value;
+            });
+
+            select.addEventListener('change', () => {
+                const field = select.dataset.field;
+                const id = select.dataset.id;
+                const newValue = select.value;
+
+                if (select.dataset.originalValue === newValue) {
+                    return;
+                }
+
+                submitUpdate(id, field, newValue, select, 'text');
+            });
+        });
+    }
+
+    function exportTableToCSV(table, filename) {
+        const rows = Array.from(table.querySelectorAll('tr'));
+        const separator = ';';
+        const csvRows = [];
+
+        if (rows.length === 0) {
+            return;
+        }
+
+        const headers = Array.from(rows[0].querySelectorAll('th')).map((header) => `"${header.innerText.trim()}"`);
+        csvRows.push(headers.join(separator));
+
+        rows.slice(1).forEach((row) => {
+            const cells = Array.from(row.querySelectorAll('td'));
+            if (!cells.length) {
+                return;
+            }
+
+            const values = cells.map((cell) => {
+                if (cell.querySelector('select')) {
+                    const select = cell.querySelector('select');
+                    const option = select.options[select.selectedIndex];
+                    return `"${(option ? option.text : '').replace(/"/g, '""')}"`;
+                }
+
+                const editable = cell.querySelector('.editable-content');
+                if (editable) {
+                    const type = editable.dataset.valueType || 'text';
+                    if (type === 'currency') {
+                        try {
+                            const numeric = parseValue(type, editable.textContent, editable);
+                            return `"${numeric ?? ''}"`;
+                        } catch (error) {
+                            return '""';
+                        }
+                    }
+                    if (type === 'date') {
+                        const raw = editable.dataset.rawValue || '';
+                        return `"${raw}"`;
+                    }
+                    return `"${editable.textContent.trim().replace(/"/g, '""')}"`;
+                }
+
+                return `"${cell.textContent.trim().replace(/"/g, '""')}"`;
+            });
+
+            csvRows.push(values.join(separator));
+        });
+
+        const blob = new Blob(["\uFEFF" + csvRows.join('\n')], { type: 'text/csv;charset=utf-8;' });
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = filename;
+        link.style.display = 'none';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+    }
+
+    const table = document.getElementById('processos-table');
+    const exportBtn = document.getElementById('export-csv-btn');
     const printBtn = document.getElementById('print-btn');
+
+    if (exportBtn && table) {
+        exportBtn.addEventListener('click', () => exportTableToCSV(table, 'relatorio-financeiro.csv'));
+    }
+
     if (printBtn) {
         printBtn.addEventListener('click', () => window.print());
     }
 
-    const exportBtn = document.getElementById('export-csv-btn');
-    if (exportBtn) {
-        exportBtn.addEventListener('click', () => {
-            const table = document.getElementById('processos-table');
-            if (table) {
-                exportTableToCSV(table, 'relatorio-servicos.csv');
-            }
-        });
-    }
-
-    /**
-     * Exporta a tabela para CSV formatado para Excel (ponto e vírgula, números e datas corretos).
-     */
-    function exportTableToCSV(table, filename) {
-        const rows = table.querySelectorAll('tr');
-        let csv = [];
-        const separator = ';'; // Ponto e vírgula para compatibilidade com Excel no Brasil
-
-        const headers = [];
-        rows[0].querySelectorAll('th').forEach(header => {
-            headers.push(`"${header.innerText.trim()}"`);
-        });
-        csv.push(headers.join(separator));
-        
-        for (let i = 1; i < rows.length; i++) {
-            const row = [], cols = rows[i].querySelectorAll('td');
-            
-            if (cols.length === 1 && cols[0].getAttribute('colspan')) continue;
-
-            cols.forEach(col => {
-                let data = '';
-                const editableContent = col.querySelector('.editable-content');
-
-                if (col.querySelector('select')) {
-                    const select = col.querySelector('select');
-                    data = select.selectedIndex > 0 ? select.options[select.selectedIndex].text : '';
-                } else if (editableContent) {
-                    const dataType = col.dataset.valueType;
-                    const rawText = editableContent.innerText.trim();
-
-                    if (dataType === 'currency') {
-                        // Converte 'R$ 1.234,56' para '1234.56'
-                        data = rawText.replace('R$', '').replace(/\./g, '').replace(',', '.').trim();
-                    } else if (dataType === 'date') {
-                        // Converte 'dd/mm/YYYY' para 'YYYY-MM-DD'
-                        if (rawText && rawText !== 'N/A') {
-                            const parts = rawText.split('/');
-                            if (parts.length === 3) {
-                                data = `${parts[2]}-${parts[1]}-${parts[0]}`;
-                            }
-                        }
-                    } else {
-                        data = rawText;
-                    }
-                } else {
-                    data = col.innerText.trim();
-                }
-                
-                data = data.replace(/"/g, '""'); // Escapa aspas duplas
-                row.push(`"${data}"`);
-            });
-            csv.push(row.join(separator));
-        }
-
-        downloadCSV(csv.join('\n'), filename);
-    }
-
-    function downloadCSV(csvContent, filename) {
-        // Usa BOM para garantir a correta interpretação de caracteres UTF-8 no Excel
-        const csvFile = new Blob(["\uFEFF" + csvContent], { type: 'text/csv;charset=utf-8;' });
-        const downloadLink = document.createElement('a');
-        
-        downloadLink.download = filename;
-        downloadLink.href = window.URL.createObjectURL(csvFile);
-        downloadLink.style.display = 'none';
-
-        document.body.appendChild(downloadLink);
-        downloadLink.click();
-        document.body.removeChild(downloadLink);
-    }
-});
+    wireEditableElements();
+})();
 </script>
-
-<?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/financeiro.php
+++ b/financeiro.php
@@ -1,28 +1,51 @@
 <?php
 session_start();
+
 require_once __DIR__ . '/app/core/auth_check.php';
-require_once __DIR__ . '/config.php'; // Garante que $pdo está disponível
+require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/app/controllers/FinanceiroController.php';
 require_once __DIR__ . '/app/core/access_control.php';
+
 require_permission(['admin', 'financeiro', 'gerencia']);
 
-// Obter a instância do PDO que deve ser definida em config.php
 global $pdo;
 
-$controller = new FinanceiroController($pdo); // Passa a instância do PDO para o controlador
+$controller = new FinanceiroController($pdo);
 
-// Verifica se é uma requisição AJAX para atualizar um campo
-if (isset($_GET['action']) && $_GET['action'] === 'update_field') {
+$action = filter_input(INPUT_GET, 'action', FILTER_SANITIZE_FULL_SPECIAL_CHARS) ?: '';
+
+if ($action === 'update_field') {
     $controller->updateFinancialField();
-} else {
-    // Coleta os parâmetros do filtro da URL para a exibição normal
-    $start_date = $_GET['start_date'] ?? date('Y-m-01');
-    $end_date = $_GET['end_date'] ?? date('Y-m-t');
-    // Removendo o filtro 'group_by' da URL para a exibição normal,
-    // mas mantendo-o para a chamada do controller para os totais agregados (que precisa de um padrão)
-    $group_by_for_totals = $_GET['group_by'] ?? 'month'; // Mantém para a agregação de totais
-
-    // Chama o método index do controlador, passando os parâmetros de filtro
-    $controller->index($start_date, $end_date, $group_by_for_totals);
+    return;
 }
-?>
+
+$startDate = filter_input(INPUT_GET, 'start_date', FILTER_SANITIZE_FULL_SPECIAL_CHARS) ?: date('Y-m-01');
+$endDate = filter_input(INPUT_GET, 'end_date', FILTER_SANITIZE_FULL_SPECIAL_CHARS) ?: date('Y-m-t');
+$groupBy = filter_input(INPUT_GET, 'group_by', FILTER_SANITIZE_FULL_SPECIAL_CHARS) ?: 'month';
+$vendedorId = filter_input(INPUT_GET, 'vendedor_id', FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) ?: null;
+$formaPagamentoId = filter_input(INPUT_GET, 'forma_pagamento_id', FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+$clienteId = filter_input(INPUT_GET, 'cliente_id', FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) ?: null;
+
+if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $startDate)) {
+    $startDate = date('Y-m-01');
+}
+
+if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $endDate)) {
+    $endDate = date('Y-m-t');
+}
+
+$allowedGroupings = ['day', 'month', 'year'];
+if (!in_array($groupBy, $allowedGroupings, true)) {
+    $groupBy = 'month';
+}
+
+$filters = [
+    'start_date' => $startDate,
+    'end_date' => $endDate,
+    'group_by' => $groupBy,
+    'vendedor_id' => $vendedorId,
+    'forma_pagamento_id' => $formaPagamentoId === false ? null : $formaPagamentoId,
+    'cliente_id' => $clienteId,
+];
+
+$controller->index($filters);


### PR DESCRIPTION
## Summary
- sanitiza os parâmetros de filtro no roteador e repassa ao controller
- reforça o controller/modelo com agregações financeiras, proteção CSRF e uso consistente de PDO
- reestrutura a view para filtros responsivos, edição inline com feedback e exportação CSV

## Testing
- php -l financeiro.php
- php -l app/controllers/FinanceiroController.php
- php -l app/models/Processo.php
- php -l app/views/financeiro/lista.php

------
https://chatgpt.com/codex/tasks/task_e_68e2fb2533ec8330818e93efd7e6bd45