### PR TITLE
Ajusta fluxo de solicitação de exclusão de prospecção

### DIFF
--- a/app/models/User.php
+++ b/app/models/User.php
@@ -179,4 +179,25 @@ class User
 
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
+
+    public function getActiveContactsByProfiles(array $profiles): array
+    {
+        if (empty($profiles)) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($profiles), '?'));
+
+        $sql = "SELECT id, nome_completo, email
+                FROM users
+                WHERE perfil IN ($placeholders)
+                  AND (ativo = 1 OR ativo IS NULL)
+                  AND email IS NOT NULL
+                  AND email <> ''";
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($profiles);
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 }


### PR DESCRIPTION
## Summary
- adiciona método no modelo de usuários para listar contatos ativos por perfil
- envia solicitações de exclusão de prospecção para e-mails gerenciais configurados e cria notificações internas
- inclui link da prospecção e mensagem do pedido no corpo do e-mail

## Testing
- php -l app/models/User.php
- php -l crm/prospeccoes/solicitar_exclusao.php

------
https://chatgpt.com/codex/tasks/task_e_68e30e7b910c8330be8d5fab18f4badd