### PR TITLE
Sincronizar exclusão de produtos com Omie

### DIFF
--- a/app/controllers/ProdutosOrcamentoController.php
+++ b/app/controllers/ProdutosOrcamentoController.php
@@ -151,23 +151,23 @@ class ProdutosOrcamentoController {
             exit();
         }
 
-        $metadataWarning = null;
+        $warningMessages = [];
 
         try {
-            $this->getOmieSyncService()->removeLocalProduct($id);
+            $this->getOmieSyncService()->deleteProduct($id);
         } catch (Exception $exception) {
-            $metadataWarning = 'Produto excluído, mas não foi possível remover os metadados locais: ' . $exception->getMessage();
+            $warningMessages[] = 'Falha ao excluir o produto na Omie: ' . $exception->getMessage();
         }
 
         if ($this->categoriaModel->deleteProdutoOrcamento($id)) {
-            if ($metadataWarning !== null) {
-                $_SESSION['warning_message'] = $metadataWarning;
-            }
             $_SESSION['success_message'] = 'Produto de Orçamento excluído com sucesso!';
+            if (!empty($warningMessages)) {
+                $_SESSION['warning_message'] = implode(' ', $warningMessages);
+            }
         } else {
             $_SESSION['error_message'] = 'Erro ao excluir o produto.';
-            if ($metadataWarning !== null) {
-                $_SESSION['warning_message'] = $metadataWarning;
+            if (!empty($warningMessages)) {
+                $_SESSION['warning_message'] = implode(' ', $warningMessages);
             }
         }
         header('Location: produtos_orcamento.php');

--- a/app/services/OmieService.php
+++ b/app/services/OmieService.php
@@ -278,6 +278,11 @@ class OmieService {
         return $this->makeRequest('/geral/produtos/', 'AlterarProduto', $payload);
     }
 
+    public function excluirProduto(array $payload): array
+    {
+        return $this->makeRequest('/geral/produtos/', 'ExcluirProduto', $payload);
+    }
+
     public function consultarProduto(array $payload): array
     {
         return $this->makeRequest('/geral/produtos/', 'ConsultarProduto', $payload);
@@ -301,6 +306,26 @@ class OmieService {
         }
 
         return $this->consultarProduto(['codigo_produto_integracao' => $codigoNormalizado]);
+    }
+
+    public function excluirProdutoPorCodigo(string $codigoProduto): array
+    {
+        $codigoNormalizado = trim($codigoProduto);
+        if ($codigoNormalizado === '') {
+            throw new InvalidArgumentException('O código do produto não pode ser vazio para exclusão na Omie.');
+        }
+
+        return $this->excluirProduto(['codigo_produto' => $codigoNormalizado]);
+    }
+
+    public function excluirProdutoPorIntegracao(string $codigoIntegracao): array
+    {
+        $codigoNormalizado = trim($codigoIntegracao);
+        if ($codigoNormalizado === '') {
+            throw new InvalidArgumentException('O código de integração do produto não pode ser vazio para exclusão na Omie.');
+        }
+
+        return $this->excluirProduto(['codigo_produto_integracao' => $codigoNormalizado]);
     }
 
     public function createProduct(array $payload): array {


### PR DESCRIPTION
## Resumo
- Ajusta o fluxo de exclusão de produtos de orçamento para chamar a nova rotina de remoção sincronizada com a Omie e reportar avisos.
- Adiciona métodos na camada de serviço Omie para chamar a API de exclusão por código ou código de integração.
- Reestrutura o serviço de sincronização para excluir produtos na Omie, limpar metadados locais com segurança e corrigir a consulta do código municipal com parâmetros válidos.

## Testes
- php -l app/controllers/ProdutosOrcamentoController.php
- php -l app/services/OmieService.php
- php -l app/services/OmieSyncService.php


------
https://chatgpt.com/codex/tasks/task_e_68e3ce69bcf083309c03331672310011