### PR TITLE
Registrar histórico e permitir exclusão de agendamentos

### DIFF
--- a/crm/agendamentos/api_eventos.php
+++ b/crm/agendamentos/api_eventos.php
@@ -9,14 +9,15 @@ require_once __DIR__ . '/../../app/core/auth_check.php';
 // 1. JOIN com 'users' e usa 'nome_completo'
 // 2. JOIN com 'clientes' e usa 'nome_cliente'
 // 3. O JOIN com clientes agora é feito a partir do agendamento, não da prospecção
-$sql = "SELECT 
-            a.id, 
-            a.titulo, 
-            a.data_inicio as start, 
+$sql = "SELECT
+            a.id,
+            a.titulo,
+            a.data_inicio as start,
             a.data_fim as end,
             a.status,
             a.local_link,
             a.observacoes,
+            a.usuario_id,
             u.nome_completo as responsavel,
             a.prospeccao_id,
             c.nome_cliente
@@ -52,13 +53,16 @@ try {
     $eventos_formatados = array_map(function($evento) {
         $colors = ['Confirmado' => '#3788d8', 'Pendente' => '#f0ad4e', 'Realizado' => '#5cb85c', 'Cancelado' => '#d9534f'];
         $evento['color'] = $colors[$evento['status']] ?? '#777';
-        
+
         $evento['extendedProps'] = [
             'responsavel' => $evento['responsavel'],
             'cliente' => $evento['nome_cliente'], // Usa a coluna correta
             'prospeccao_id' => $evento['prospeccao_id'],
             'local_link' => $evento['local_link'],
-            'observacoes' => $evento['observacoes']
+            'observacoes' => $evento['observacoes'],
+            'usuario_id' => (int) $evento['usuario_id'],
+            'canDelete' => $evento['usuario_id'] == ($_SESSION['user_id'] ?? null)
+                || in_array($_SESSION['user_perfil'] ?? '', ['admin', 'gerencia', 'supervisor'], true)
         ];
         return $evento;
     }, $eventos);

--- a/crm/agendamentos/calendario.php
+++ b/crm/agendamentos/calendario.php
@@ -113,6 +113,10 @@ if ($prefillTitle !== '') {
                         </select>
                     </div>
                 </div>
+                <div>
+                    <label for="data_dia" class="block text-sm font-medium text-gray-700">Data do Agendamento</label>
+                    <input type="date" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" id="data_dia" name="data_dia" required>
+                </div>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label for="data_inicio_hora" class="block text-sm font-medium text-gray-700">Hora de Início</label>
@@ -175,6 +179,7 @@ document.addEventListener('DOMContentLoaded', function() {
     var btnCloseModal = document.getElementById('btnCloseModal');
     var btnCancelarAgendamento = document.getElementById('btnCancelarAgendamento');
     
+    var dataDiaInput = document.getElementById('data_dia');
     var dataInicioHoraInput = document.getElementById('data_inicio_hora');
     var dataFimHoraInput = document.getElementById('data_fim_hora');
     
@@ -224,8 +229,10 @@ document.addEventListener('DOMContentLoaded', function() {
             const day = String(selectedCalendarDate.getDate()).padStart(2, '0');
             selectedDateStr = `${year}-${month}-${day}`;
 
+            dataDiaInput.value = selectedDateStr;
+
             dataInicioHoraInput.value = selectedCalendarDate.toTimeString().slice(0, 5); // HH:MM
-            
+
             var dataFimPadrao = new Date(selectedCalendarDate.getTime() + 60 * 60 * 1000); // Adiciona 1 hora
             dataFimHoraInput.value = dataFimPadrao.toTimeString().slice(0, 5); // HH:MM
 
@@ -237,14 +244,18 @@ document.addEventListener('DOMContentLoaded', function() {
         },
 
         eventClick: function(info) {
-            info.jsEvent.preventDefault(); 
+            info.jsEvent.preventDefault();
 
             if (info.el._tippy) {
                 info.el._tippy.destroy();
             }
 
             const props = info.event.extendedProps;
+            const canDelete = Boolean(props.canDelete);
             let link_prospeccao = props.prospeccao_id ? `<a href="${API_PROSPECCAO_URL}/detalhes.php?id=${props.prospeccao_id}" class="block mt-3 text-center bg-blue-500 text-white py-2 px-4 rounded-md text-sm hover:bg-blue-600 transition-colors">Ver Prospecção</a>` : '';
+            const deleteButtonHtml = canDelete
+                ? `<button type="button" data-action="delete-agendamento" data-id="${info.event.id}" class="mt-3 w-full bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1">Excluir agendamento</button>`
+                : '';
 
             let content = `
                 <div class="text-left text-sm">
@@ -254,17 +265,65 @@ document.addEventListener('DOMContentLoaded', function() {
                     ${props.local_link ? `<p class="mb-1"><strong>Link:</strong> <a href="${props.local_link}" target="_blank" class="text-blue-400 hover:underline">Acessar Reunião</a></p>` : ''}
                     ${props.observacoes ? `<p class="mt-3 border-t border-gray-500 pt-2 text-gray-200"><strong>Obs:</strong> ${props.observacoes}</p>` : ''}
                     ${link_prospeccao}
+                    ${deleteButtonHtml}
                 </div>
             `;
-            
+
             tippy(info.el, {
                 content: content,
                 allowHTML: true,
-                trigger: 'manual', 
-                interactive: true, 
+                trigger: 'manual',
+                interactive: true,
                 placement: 'top',
                 animation: 'scale-subtle',
                 appendTo: () => document.body,
+                onShown(instance) {
+                    const deleteButton = instance.popper.querySelector('[data-action="delete-agendamento"]');
+                    if (!deleteButton || deleteButton.dataset.bound === '1') {
+                        return;
+                    }
+
+                    deleteButton.dataset.bound = '1';
+
+                    deleteButton.addEventListener('click', function(event) {
+                        event.preventDefault();
+
+                        if (!confirm('Tem certeza de que deseja excluir este agendamento?')) {
+                            return;
+                        }
+
+                        deleteButton.disabled = true;
+                        deleteButton.textContent = 'Excluindo...';
+
+                        fetch(`${API_BASE_URL}/excluir_agendamento.php`, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/x-www-form-urlencoded'
+                            },
+                            body: new URLSearchParams({ agendamento_id: info.event.id }).toString()
+                        })
+                        .then(response => response.json())
+                        .then(data => {
+                            if (data.success) {
+                                alert(data.message || 'Agendamento excluído com sucesso.');
+                                if (info.el._tippy) {
+                                    info.el._tippy.hide();
+                                }
+                                calendar.refetchEvents();
+                            } else {
+                                alert('Erro ao excluir agendamento: ' + (data.message || 'Tente novamente.'));
+                            }
+                        })
+                        .catch(error => {
+                            console.error('Erro ao excluir agendamento:', error);
+                            alert('Ocorreu um erro de comunicação. Tente novamente.');
+                        })
+                        .finally(() => {
+                            deleteButton.disabled = false;
+                            deleteButton.textContent = 'Excluir agendamento';
+                        });
+                    });
+                },
                 onClickOutside(instance, event) {
                     instance.hide();
                 },
@@ -294,11 +353,31 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // --- Lógica dos Campos de Hora para preencher os campos hidden de datetime ---
     function updateHiddenDateTime() {
+        if (dataDiaInput.value) {
+            selectedDateStr = dataDiaInput.value;
+        }
+
         if (selectedDateStr && dataInicioHoraInput.value && dataFimHoraInput.value) {
             dataInicioHiddenInput.value = `${selectedDateStr} ${dataInicioHoraInput.value}:00`;
             dataFimHiddenInput.value = `${selectedDateStr} ${dataFimHoraInput.value}:00`;
         }
     }
+
+    dataDiaInput.addEventListener('change', function() {
+        if (this.value) {
+            selectedDateStr = this.value;
+
+            var parts = this.value.split('-');
+            if (parts.length === 3) {
+                var year = parseInt(parts[0], 10);
+                var month = parseInt(parts[1], 10) - 1;
+                var day = parseInt(parts[2], 10);
+                selectedCalendarDate = new Date(year, month, day);
+            }
+
+            updateHiddenDateTime();
+        }
+    });
 
     dataInicioHoraInput.addEventListener('change', updateHiddenDateTime);
     dataFimHoraInput.addEventListener('change', updateHiddenDateTime);
@@ -474,6 +553,8 @@ document.addEventListener('DOMContentLoaded', function() {
         var month = String(selectedCalendarDate.getMonth() + 1).padStart(2, '0');
         var day = String(selectedCalendarDate.getDate()).padStart(2, '0');
         selectedDateStr = `${year}-${month}-${day}`;
+
+        dataDiaInput.value = selectedDateStr;
 
         var startHours = String(now.getHours()).padStart(2, '0');
         var startMinutes = String(now.getMinutes()).padStart(2, '0');

--- a/crm/agendamentos/excluir_agendamento.php
+++ b/crm/agendamentos/excluir_agendamento.php
@@ -1,0 +1,101 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../app/core/auth_check.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Content-Type: application/json');
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Método não permitido.']);
+    exit();
+}
+
+$redirectTo = isset($_POST['redirect_to']) && $_POST['redirect_to'] !== '' ? $_POST['redirect_to'] : null;
+
+function respondWithError(string $message, ?string $redirectTo): void
+{
+    if ($redirectTo) {
+        $_SESSION['error_message'] = $message;
+        header('Location: ' . $redirectTo);
+    } else {
+        header('Content-Type: application/json');
+        echo json_encode(['success' => false, 'message' => $message]);
+    }
+
+    exit();
+}
+
+function respondWithSuccess(string $message, ?string $redirectTo): void
+{
+    if ($redirectTo) {
+        $_SESSION['success_message'] = $message;
+        header('Location: ' . $redirectTo);
+    } else {
+        header('Content-Type: application/json');
+        echo json_encode(['success' => true, 'message' => $message]);
+    }
+
+    exit();
+}
+
+$currentUserId = (int) ($_SESSION['user_id'] ?? 0);
+if ($currentUserId <= 0) {
+    respondWithError('Usuário não autenticado.', $redirectTo);
+}
+
+$agendamentoId = filter_input(INPUT_POST, 'agendamento_id', FILTER_VALIDATE_INT);
+if (!$agendamentoId) {
+    respondWithError('Agendamento inválido.', $redirectTo);
+}
+
+try {
+    $stmt = $pdo->prepare('SELECT id, usuario_id, prospeccao_id, titulo, data_inicio FROM agendamentos WHERE id = :id');
+    $stmt->bindValue(':id', $agendamentoId, PDO::PARAM_INT);
+    $stmt->execute();
+    $agendamento = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$agendamento) {
+        respondWithError('Agendamento não encontrado.', $redirectTo);
+    }
+
+    $perfisGerenciais = ['admin', 'gerencia', 'supervisor'];
+    $usuarioPodeGerenciar = in_array($_SESSION['user_perfil'] ?? '', $perfisGerenciais, true);
+
+    if ((int) $agendamento['usuario_id'] !== $currentUserId && !$usuarioPodeGerenciar) {
+        respondWithError('Você não tem permissão para excluir este agendamento.', $redirectTo);
+    }
+
+    $pdo->beginTransaction();
+
+    $stmtDelete = $pdo->prepare('DELETE FROM agendamentos WHERE id = :id');
+    $stmtDelete->bindValue(':id', $agendamentoId, PDO::PARAM_INT);
+    $stmtDelete->execute();
+
+    if (!empty($agendamento['prospeccao_id'])) {
+        $dataInicio = new DateTime($agendamento['data_inicio']);
+        $descricaoInteracao = sprintf(
+            'Agendamento cancelado: %s em %s.',
+            $agendamento['titulo'],
+            $dataInicio->format('d/m/Y H:i')
+        );
+
+        $stmtInteracao = $pdo->prepare(
+            'INSERT INTO interacoes (prospeccao_id, usuario_id, observacao, tipo) VALUES (:prospeccao_id, :usuario_id, :observacao, :tipo)'
+        );
+        $stmtInteracao->execute([
+            ':prospeccao_id' => (int) $agendamento['prospeccao_id'],
+            ':usuario_id' => $currentUserId,
+            ':observacao' => $descricaoInteracao,
+            ':tipo' => 'reuniao'
+        ]);
+    }
+
+    $pdo->commit();
+
+    respondWithSuccess('Agendamento excluído com sucesso.', $redirectTo);
+} catch (PDOException $exception) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    error_log('Erro em excluir_agendamento.php: ' . $exception->getMessage());
+    respondWithError('Não foi possível excluir o agendamento.', $redirectTo);
+}

--- a/crm/agendamentos/salvar_agendamento.php
+++ b/crm/agendamentos/salvar_agendamento.php
@@ -1,49 +1,218 @@
 <?php
-// Arquivo: crm/agendamentos/salvar_agendamento.php (VERSÃO FINAL E INTELIGENTE)
-
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../app/core/auth_check.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    // Para chamadas diretas, redireciona para o dashboard
     header('Location: ' . APP_URL . '/crm/dashboard.php');
     exit();
 }
 
-try {
-    // Lógica de salvar (que já estava correta)
-    $titulo = trim($_POST['titulo'] ?? '');
-    // ... (resto da captura de dados)
-    
-    // ... (lógica de INSERT no banco de dados) ...
-    // Assume-se que a inserção foi bem-sucedida
+$redirectTo = isset($_POST['redirect_to']) && $_POST['redirect_to'] !== '' ? $_POST['redirect_to'] : null;
 
-    // --- INÍCIO DA CORREÇÃO ---
-    // Verifica se deve redirecionar ou retornar JSON
-    if (isset($_POST['redirect_to']) && !empty($_POST['redirect_to'])) {
-        // Veio do formulário de detalhes, então redireciona
-        $_SESSION['success_message'] = "Agendamento criado com sucesso!";
-        header('Location: ' . $_POST['redirect_to']);
-        exit();
+function normalizeDateTime(?string $value): ?string
+{
+    if ($value === null) {
+        return null;
+    }
+
+    $value = trim($value);
+
+    if ($value === '') {
+        return null;
+    }
+
+    $formats = [
+        'Y-m-d H:i:s',
+        'Y-m-d H:i',
+        'Y-m-d\TH:i',
+        'Y-m-d\TH:i:s'
+    ];
+
+    foreach ($formats as $format) {
+        $date = DateTime::createFromFormat($format, $value);
+        if ($date instanceof DateTime) {
+            return $date->format('Y-m-d H:i:s');
+        }
+    }
+
+    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+        return $value . ' 00:00:00';
+    }
+
+    return null;
+}
+
+function respondWithError(string $message, ?string $redirectTo): void
+{
+    if ($redirectTo) {
+        $_SESSION['error_message'] = $message;
+        header('Location: ' . $redirectTo);
     } else {
-        // Veio do calendário, então retorna JSON
+        header('Content-Type: application/json');
+        echo json_encode(['success' => false, 'message' => $message]);
+    }
+
+    exit();
+}
+
+function respondWithSuccess(?string $redirectTo): void
+{
+    if ($redirectTo) {
+        $_SESSION['success_message'] = 'Agendamento criado com sucesso!';
+        header('Location: ' . $redirectTo);
+    } else {
         header('Content-Type: application/json');
         echo json_encode(['success' => true]);
-        exit();
     }
-    // --- FIM DA CORREÇÃO ---
 
-} catch (PDOException $e) {
-    // Lida com erros
-    error_log("Erro em salvar_agendamento.php: " . $e->getMessage());
-    if (isset($_POST['redirect_to'])) {
-        $_SESSION['error_message'] = "Erro ao salvar o agendamento.";
-        header('Location: ' . $_POST['redirect_to']);
-        exit();
-    } else {
-        header('Content-Type: application/json');
-        echo json_encode(['success' => false, 'message' => 'Ocorreu um erro interno.']);
-        exit();
-    }
+    exit();
 }
-?>
+
+try {
+    $titulo = trim($_POST['titulo'] ?? '');
+    if ($titulo === '') {
+        throw new InvalidArgumentException('Informe o título do agendamento.');
+    }
+
+    $usuarioId = isset($_POST['usuario_id']) && $_POST['usuario_id'] !== ''
+        ? (int) $_POST['usuario_id']
+        : (int) ($_SESSION['user_id'] ?? 0);
+
+    if ($usuarioId <= 0) {
+        throw new InvalidArgumentException('Usuário responsável inválido.');
+    }
+
+    $clienteId = isset($_POST['cliente_id']) && $_POST['cliente_id'] !== ''
+        ? (int) $_POST['cliente_id']
+        : null;
+
+    $prospeccaoId = isset($_POST['prospeccao_id']) && $_POST['prospeccao_id'] !== ''
+        ? (int) $_POST['prospeccao_id']
+        : null;
+
+    $dataInicio = normalizeDateTime($_POST['data_inicio'] ?? null);
+    $dataFim = normalizeDateTime($_POST['data_fim'] ?? null);
+
+    if (!$dataInicio && !empty($_POST['data_dia']) && !empty($_POST['data_inicio_hora'])) {
+        $dataInicio = normalizeDateTime($_POST['data_dia'] . ' ' . $_POST['data_inicio_hora']);
+    }
+
+    if (!$dataFim && !empty($_POST['data_dia']) && !empty($_POST['data_fim_hora'])) {
+        $dataFim = normalizeDateTime($_POST['data_dia'] . ' ' . $_POST['data_fim_hora']);
+    }
+
+    if (!$dataInicio || !$dataFim) {
+        throw new InvalidArgumentException('Informe data e hora válidas.');
+    }
+
+    $inicioDateTime = new DateTime($dataInicio);
+    $fimDateTime = new DateTime($dataFim);
+
+    if ($fimDateTime <= $inicioDateTime) {
+        throw new InvalidArgumentException('O horário final deve ser posterior ao início.');
+    }
+
+    if ($prospeccaoId && !$clienteId) {
+        $stmtProspeccao = $pdo->prepare('SELECT cliente_id FROM prospeccoes WHERE id = :id');
+        $stmtProspeccao->bindValue(':id', $prospeccaoId, PDO::PARAM_INT);
+        $stmtProspeccao->execute();
+        $clienteIdFromProspeccao = $stmtProspeccao->fetchColumn();
+
+        if ($clienteIdFromProspeccao) {
+            $clienteId = (int) $clienteIdFromProspeccao;
+        }
+    }
+
+    $localLink = trim($_POST['local_link'] ?? '');
+    $observacoes = trim($_POST['observacoes'] ?? '');
+    $status = trim($_POST['status'] ?? 'Confirmado');
+    if ($status === '') {
+        $status = 'Confirmado';
+    }
+
+    $pdo->beginTransaction();
+
+    $sql = 'INSERT INTO agendamentos (
+                titulo,
+                cliente_id,
+                prospeccao_id,
+                usuario_id,
+                data_inicio,
+                data_fim,
+                local_link,
+                observacoes,
+                status
+            ) VALUES (
+                :titulo,
+                :cliente_id,
+                :prospeccao_id,
+                :usuario_id,
+                :data_inicio,
+                :data_fim,
+                :local_link,
+                :observacoes,
+                :status
+            )';
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->bindValue(':titulo', $titulo, PDO::PARAM_STR);
+    if ($clienteId !== null) {
+        $stmt->bindValue(':cliente_id', $clienteId, PDO::PARAM_INT);
+    } else {
+        $stmt->bindValue(':cliente_id', null, PDO::PARAM_NULL);
+    }
+    if ($prospeccaoId !== null) {
+        $stmt->bindValue(':prospeccao_id', $prospeccaoId, PDO::PARAM_INT);
+    } else {
+        $stmt->bindValue(':prospeccao_id', null, PDO::PARAM_NULL);
+    }
+    $stmt->bindValue(':usuario_id', $usuarioId, PDO::PARAM_INT);
+    $stmt->bindValue(':data_inicio', $dataInicio);
+    $stmt->bindValue(':data_fim', $dataFim);
+    if ($localLink !== '') {
+        $stmt->bindValue(':local_link', $localLink, PDO::PARAM_STR);
+    } else {
+        $stmt->bindValue(':local_link', null, PDO::PARAM_NULL);
+    }
+    if ($observacoes !== '') {
+        $stmt->bindValue(':observacoes', $observacoes, PDO::PARAM_STR);
+    } else {
+        $stmt->bindValue(':observacoes', null, PDO::PARAM_NULL);
+    }
+    $stmt->bindValue(':status', $status, PDO::PARAM_STR);
+
+    $stmt->execute();
+
+    if ($prospeccaoId !== null) {
+        $descricaoInteracao = sprintf(
+            'Agendamento criado: %s em %s.',
+            $titulo,
+            $inicioDateTime->format('d/m/Y H:i')
+        );
+
+        $stmtInteracao = $pdo->prepare(
+            'INSERT INTO interacoes (prospeccao_id, usuario_id, observacao, tipo) VALUES (:prospeccao_id, :usuario_id, :observacao, :tipo)'
+        );
+        $stmtInteracao->execute([
+            ':prospeccao_id' => $prospeccaoId,
+            ':usuario_id' => $usuarioId,
+            ':observacao' => $descricaoInteracao,
+            ':tipo' => 'reuniao'
+        ]);
+    }
+
+    $pdo->commit();
+
+    respondWithSuccess($redirectTo);
+} catch (InvalidArgumentException $exception) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    respondWithError($exception->getMessage(), $redirectTo);
+} catch (PDOException $exception) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    error_log('Erro em salvar_agendamento.php: ' . $exception->getMessage());
+    respondWithError('Ocorreu um erro interno ao salvar o agendamento.', $redirectTo);
+}


### PR DESCRIPTION
## Summary
- registrar interações automáticas ao criar e excluir agendamentos vinculados a uma prospecção
- disponibilizar endpoint dedicado e botão no calendário para excluir agendamentos com validação de permissão
- expor na API de eventos a permissão de exclusão para controlar a exibição da ação no frontend

## Testing
- php -l crm/agendamentos/calendario.php
- php -l crm/agendamentos/api_eventos.php
- php -l crm/agendamentos/salvar_agendamento.php
- php -l crm/agendamentos/excluir_agendamento.php

------
https://chatgpt.com/codex/tasks/task_e_68e426e66b948330a83e46deb57af63a