### PR TITLE
Atualiza opções de origem de leads

### DIFF
--- a/app/views/processos/form.php
+++ b/app/views/processos/form.php
@@ -201,7 +201,20 @@ $paymentDateTwo = $processo['data_pagamento_2'] ?? $formData['data_pagamento_2']
                 <select name="orcamento_origem" id="orcamento_origem" class="mt-1 block w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
                     <option value="">Selecione a origem</option>
                     <?php
-                    $origens = ['Bitrix', 'Facebook', 'Instagram', 'Google', 'Indicação Cartório', 'Indicação Cliente', 'Website', 'LinkedIn', 'Whatsapp'];
+                    $origens = [
+                        'Google (Anúncios/SEO)',
+                        'Website',
+                        'Indicação Cliente',
+                        'Instagram',
+                        'LinkedIn',
+                        'Facebook',
+                        'Whatsapp',
+                        'Bitrix',
+                        'Call',
+                        'Indicação Cartório',
+                        'Evento',
+                        'Outro',
+                    ];
                     foreach ($origens as $origem) {
                         $selected = (($processo['orcamento_origem'] ?? '') == $origem) ? 'selected' : '';
                         echo "<option value='{$origem}' {$selected}>{$origem}</option>";

--- a/crm/clientes/novo.php
+++ b/crm/clientes/novo.php
@@ -39,14 +39,16 @@ if (strpos($redirectUrl, APP_URL) !== 0) {
                     <label for="canal_origem" class="block text-sm font-medium text-gray-700">Canal de Origem</label>
                     <select name="canal_origem" id="canal_origem" required class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3">
                         <option value="">Selecione um canal</option>
-                        <option value="Call">Call</option>
-                        <option value="LinkedIn">LinkedIn</option>
-                        <option value="Instagram">Instagram</option>
-                        <option value="Whatsapp">Whatsapp</option>
-                        <option value="Indicação Cliente">Indicação Cliente</option>
-                        <option value="Indicação Cartório">Indicação Cartório</option>
+                        <option value="Google (Anúncios/SEO)">Google (Anúncios/SEO)</option>
                         <option value="Website">Website</option>
+                        <option value="Indicação Cliente">Indicação Cliente</option>
+                        <option value="Instagram">Instagram</option>
+                        <option value="LinkedIn">LinkedIn</option>
+                        <option value="Facebook">Facebook</option>
+                        <option value="Whatsapp">Whatsapp</option>
                         <option value="Bitrix">Bitrix</option>
+                        <option value="Call">Call</option>
+                        <option value="Indicação Cartório">Indicação Cartório</option>
                         <option value="Evento">Evento</option>
                         <option value="Outro">Outro</option>
                     </select>


### PR DESCRIPTION
## Resumo
- alinhar as opções de origem do orçamento com a nova lista padronizada
- atualizar o cadastro de leads para usar os mesmos canais de origem

## Testes
- php -l app/views/processos/form.php
- php -l crm/clientes/novo.php

------
https://chatgpt.com/codex/tasks/task_e_68e571e7a36c83309a4b711830cf430d