### PR TITLE
Fix: carregar comentários no detalhe do processo

### DIFF
--- a/app/controllers/ProcessosController.php
+++ b/app/controllers/ProcessosController.php
@@ -1223,12 +1223,14 @@ class ProcessosController
         $translationAttachments = $this->processoModel->getAnexosPorCategoria($id, ['traducao']);
         $crcAttachments = $this->processoModel->getAnexosPorCategoria($id, ['crc']);
         $paymentProofAttachments = $this->processoModel->getAnexosPorCategoria($id, ['comprovante']);
+        $comments = $this->processoModel->getComentariosByProcessoId($id);
         $this->render('processos/detalhe', [
             'processo' => $processo_info['processo'],
             'documentos' => $processo_info['documentos'],
             'translationAttachments' => $translationAttachments,
             'crcAttachments' => $crcAttachments,
             'paymentProofAttachments' => $paymentProofAttachments,
+            'comentarios' => $comments,
             'pageTitle' => 'Detalhes do Processo',
         ]);
     }


### PR DESCRIPTION
## Resumo
- recuperar os comentários do processo ao montar a página de detalhes
- repassar a lista de comentários para a view `processos/detalhe`

## Testes
- não aplicável

------
https://chatgpt.com/codex/tasks/task_e_68e5c326cb2c833087869316c022df79