### PR TITLE
Ajusta cards de serviços no dashboard

### DIFF
--- a/app/models/Processo.php
+++ b/app/models/Processo.php
@@ -1214,7 +1214,8 @@ public function create($data, $files)
     public function getDashboardStats()
     {
         $sql = "SELECT
-            COUNT(CASE WHEN status_processo IN ('Serviço Pendente', 'Serviço pendente', 'Serviço em Andamento', 'Serviço em andamento') THEN 1 END) as processos_ativos,
+            COUNT(CASE WHEN status_processo IN ('Serviço em Andamento', 'Serviço em andamento') THEN 1 END) as processos_ativos,
+            COUNT(CASE WHEN status_processo IN ('Serviço Pendente', 'Serviço pendente') THEN 1 END) as servicos_pendentes,
             COUNT(CASE WHEN status_processo IN ('Orçamento', 'Orçamento Pendente') THEN 1 END) as orcamentos_pendentes,
             COUNT(CASE WHEN status_processo IN ('Concluído', 'Finalizado') AND MONTH(data_finalizacao_real) = MONTH(CURDATE()) AND YEAR(data_finalizacao_real) = YEAR(CURDATE()) THEN 1 END) as finalizados_mes,
             COUNT(CASE WHEN traducao_prazo_data < CURDATE() AND status_processo NOT IN ('Concluído', 'Finalizado', 'Arquivado', 'Cancelado', 'Recusado') THEN 1 END) as processos_atrasados
@@ -1225,7 +1226,13 @@ public function create($data, $files)
             return $stmt->fetch(PDO::FETCH_ASSOC);
         } catch (PDOException $e) {
             error_log("Erro ao buscar estatísticas do dashboard: " . $e->getMessage());
-            return ['processos_ativos' => 0, 'orcamentos_pendentes' => 0, 'finalizados_mes' => 0, 'processos_atrasados' => 0];
+            return [
+                'processos_ativos' => 0,
+                'servicos_pendentes' => 0,
+                'orcamentos_pendentes' => 0,
+                'finalizados_mes' => 0,
+                'processos_atrasados' => 0,
+            ];
         }
     }
 

--- a/app/views/dashboard/main.php
+++ b/app/views/dashboard/main.php
@@ -88,7 +88,11 @@ $selectedStatusNormalized = $selectedStatusInfo['normalized'];
         <div class="grid grid-cols-1 sm:grid-cols-1 gap-4">
             <div class="bg-white p-4 rounded-lg shadow-md flex items-center">
                 <div class="bg-blue-100 p-2 rounded-full"><svg class="w-6 h-6 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a2 2 0 01-2 2H6a2 2 0 01-2-2V4z"></path></svg></div>
-                <div class="ml-2"><p class="text-gray-500 text-sm">Serviços Ativos</p><p class="text-2xl font-bold text-gray-800"><?php echo $dashboardStats['processos_ativos'] ?? 0; ?></p></div>
+                <div class="ml-2"><p class="text-gray-500 text-sm">Serviços em Andamento</p><p class="text-2xl font-bold text-gray-800"><?php echo $dashboardStats['processos_ativos'] ?? 0; ?></p></div>
+            </div>
+            <div class="bg-white p-4 rounded-lg shadow-md flex items-center">
+                <div class="bg-orange-100 p-2 rounded-full"><svg class="w-6 h-6 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5 5a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg></div>
+                <div class="ml-2"><p class="text-gray-500 text-sm">Serviços Pendentes</p><p class="text-2xl font-bold text-gray-800"><?php echo $dashboardStats['servicos_pendentes'] ?? 0; ?></p></div>
             </div>
             <div class="bg-white p-4 rounded-lg shadow-md flex items-center">
                 <div class="bg-yellow-100 p-2 rounded-full"><svg class="w-6 h-6 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path></svg></div>


### PR DESCRIPTION
## Summary
- ajusta a consulta de estatísticas para separar serviços em andamento e pendentes
- atualiza os cards do dashboard para exibir o novo contador de serviços pendentes

## Testing
- php -l app/models/Processo.php
- php -l app/views/dashboard/main.php

------
https://chatgpt.com/codex/tasks/task_e_68e6538a906c83308d4d2f2edc2bcc97